### PR TITLE
[DF-275] Adding PR template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,0 +1,40 @@
+## Why? :open_book:
+_Replace me for a cool overview of why this PR is being created. You can
+refer to the Jira task or Github issue here too. Never forget to put the
+tag of a related Jira task in the title._
+
+## What? :wrench:
+_Replace me for a detailed explanation of what is being modified._
+_Want to add some awesome bullet points?_
+- _First changes;_
+- _Second changes;_
+- _..._
+
+_Want to add some cool checkboxes?_
+- [X] _First changes;_
+- [X] _Second changes;_
+- [ ] _..._
+
+## Type of change :file_cabinet:
+_Please delete options that are not relevant._
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+- [ ] Release
+
+## How everything was tested? :straight_ruler:
+_Have you achieved all the acceptance criteria? How?_
+_Is there any alternative flow in the testing process that you want to describe?_
+
+## Checklist :memo:
+- [ ] I have added labels to distinguish the type of pull request.
+- [ ] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
+- [ ] I have performed a self-review of my own code;
+- [ ] I have made corresponding changes to the documentation;
+- [ ] I have added tests that prove my fix is effective or that my feature works;
+- [ ] I have made sure that new and existing unit tests pass locally with my changes;
+
+## Attention Points :warning:
+_Replace me for what the reviewer will need to pay attention to in the PR or just to cover any concerns after the merge._


### PR DESCRIPTION
Adding PR template to project, therefore we can have a more descriptive info regarding changes and checklist of testing, documentation, etc.