### PR TITLE
[DF280] Add docstring convention rule to flake8

### DIFF
--- a/hive_metastore_client/__init__.py
+++ b/hive_metastore_client/__init__.py
@@ -1,0 +1,1 @@
+"""Hive Metastore Client."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,6 @@ per-file-ignores =
     # We will not check for docstrings or the use of asserts in tests
     tests/*:D,S101
     setup.py:D,S101
-    hive_metastore_client/__init__.py:D,S101
 
 [isort]
 line_length = 88


### PR DESCRIPTION
## Why? :open_book:
We want the flake8 to validate the code docstrings

## What? :wrench:
- I tested the `all` value that doesn't seem to work. So I defined the numpy convention that seemed to work well with our (reStructuredText) standard

## How everything was tested? :straight_ruler:
make checks
