### PR TITLE
Fix Makefile command order for make apply-style

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,8 @@ checks: style-check quality-check type-check
 .PHONY: apply-style
 ## fix stylistic errors with black
 apply-style:
-	@python -m black -t py36 --exclude="build/|buck-out/|dist/|_build/|pip/|\.pip/|\.git/|\.hg/|\.mypy_cache/|\.tox/|\.venv/" .
 	@python -m isort -rc hive_metastore_client/ tests/
+	@python -m black -t py36 --exclude="build/|buck-out/|dist/|_build/|pip/|\.pip/|\.git/|\.hg/|\.mypy_cache/|\.tox/|\.venv/" .
 
 .PHONY: clean
 ## clean unused artifacts


### PR DESCRIPTION
## Why? :open_book:
This project uses the isort lib to automatically sort the imports. This lib also changes the import line break style (\ -> ()).
After the black was performed the isort changed the imports style. 
This made the black -check to fail. 

## What? :wrench:
- perform the isort command before the black reformating. Then the black -check will be ok.

## Type of change :file_cabinet:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Release

## How everything was tested? :straight_ruler:
Running commands.

## Checklist :memo:
- [x] I have added labels to distinguish the type of pull request.
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] I have made sure that new and existing unit tests pass locally with my changes;
