### PR TITLE
[DF-289] Update Docs

### DIFF
--- a/docs/requirements.docs.txt
+++ b/docs/requirements.docs.txt
@@ -3,3 +3,5 @@ Sphinx==3.1.1
 sphinx-rtd-theme==0.4.3
 sphinxemoji==0.1.6
 typing-extensions==3.7.4.2
+thrift==0.13.0
+

--- a/docs/source/getstarted.md
+++ b/docs/source/getstarted.md
@@ -1,0 +1,27 @@
+# Getting Started
+
+Hive Metastore Client depends on **Python 3.7+**.
+
+Python Package Index hosts reference to a pip-installable module of this library, using it is as straightforward as including it on your project's requirements.
+
+```bash
+pip install hive-metastore-client
+```
+
+Or after listing `hive-metastore-client` in your `requirements.txt` file:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Discovering Hive Metastore Client
+
+Welcome to **Discovering Hive Metastore Client** tutorial series! Click on the following links to open the tutorials:
+
+**[#1 Create a database](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/create_database.py)**
+
+**[#2 Create a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/create_table.py)**
+
+**[#3 Add columns to a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/add_columns_to_table.py)**
+
+// TODO: Give examples and explain better how to use each Builder

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,7 +15,7 @@ An example of how to use the library for running DML commands in hive metastore:
     with HiveMetastoreClient(HIVE_HOST, HIVE_PORT) as hive_metastore_client:
         hive_metastore_client.create_database(database)
 
-To learn more use cases in practice, see Hive Metastore Client's examples
+To learn more use cases in practice, see [Hive Metastore Client's examples](https://github.com/quintoandar/hive-metastore-client/blob/main/examples)
 
 
 Navigation

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,18 +1,19 @@
-.. Hive Metastore Client documentation master file.
+Hive Metastore Client
+=====================
+Made with |:heart:| by the **Data Engineering** team from `QuintoAndar <https://github.com/quintoandar/>`_.
 
-Welcome to Hive Metastore Client's documentation!
-=============================================================================================
+A client for connecting and running DMLs on Hive Metastore using Thrift protocol.
+
+An example of how to use the library for running DML commands in hive metastore:
+
+To learn more use cases in practice, see `Hive Metastore Client's examples <https://github.com/quintoandar/hive-metastore-client/tree/main/examples/>`_
+
+
+Navigation
+^^^^^^^^^^
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
 
-   hive_metastore_client.rst
-   hive_metastore_client.builders.rst
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+   getstarted
+   modules

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,16 @@ A client for connecting and running DMLs on Hive Metastore using Thrift protocol
 
 An example of how to use the library for running DML commands in hive metastore:
 
-To learn more use cases in practice, see `Hive Metastore Client's examples <https://github.com/quintoandar/hive-metastore-client/tree/main/examples/>`_
+.. code-block:: python
+
+    from hive_metastore_client.builders.database_builder import DatabaseBuilder
+    from hive_metastore_client.hive_mestastore_client import HiveMetastoreClient
+
+    database = DatabaseBuilder(name='new_db').build()
+    with HiveMetastoreClient(HIVE_HOST, HIVE_PORT) as hive_metastore_client:
+        hive_metastore_client.create_database(database)
+
+To learn more use cases in practice, see Hive Metastore Client's examples
 
 
 Navigation

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,0 +1,7 @@
+API Specification
+=================
+
+.. toctree::
+   :maxdepth: 4
+
+   hive_metastore_client


### PR DESCRIPTION
## Why? :open_book:
We want to have a nice information design in the [ReadtheDocs page](https://hive-metastore-client.readthedocs.io/en/latest/).

## What? :wrench:
- add getting started menu
- move API specification into one separated section
- refactor index
- fix: add the dependency in requirements.doc.txt (the [build](https://readthedocs.org/projects/hive-metastore-client/builds/12474636/) in RtD was silent failing)

## Type of change :file_cabinet:

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

## Attention Points :warning:
Now we should review and enrich the docs in RtD
