### PR TITLE
[DF-304] Add docs about Builders and Thrift

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ with HiveMetastoreClient(HIVE_HOST, HIVE_PORT) as hive_metastore_client:
     hive_metastore_client.create_database(database) 
 ```
 
-To learn more use cases in practice, see [Hive Metastore Client's examples](https://github.com/quintoandar/hive-metastore-client/tree/main/examples)  
+To learn more use cases in practice, see [Hive Metastore Client examples](https://github.com/quintoandar/hive-metastore-client/tree/main/examples)  
 
 ## Requirements and Installation
 Hive Metastore Client depends on **Python 3.7+**
 
-[Python Package Index](https://quintoandar.github.io/python-package-server/) hosts reference to a pip-installable module of this library, using it is as straightforward as including it on your project's requirements.
+[Python Package Index](https://pypi.org/project/hive-metastore-client/) hosts reference to a pip-installable module of this library, using it is as straightforward as including it on your project's requirements.
 
 ```bash
 pip install hive-metastore-client

--- a/docs/source/builders.md
+++ b/docs/source/builders.md
@@ -1,0 +1,19 @@
+# Builders
+
+Willing to isolate its dependencies from users code, this library implements 
+the [builder pattern](https://refactoring.guru/design-patterns/builder/python/example).
+
+So instead of manually creating the Thrift objects for dealing with the
+Hive Metastore server, you can use the [builders](https://github.com/quintoandar/hive-metastore-client/tree/main/hive_metastore_client/builders).
+
+Each builder reflects the Thrift object's characteristics that it is building.
+For more information about the object particularities you can 
+try finding more information in the [hive_metastore.thrift](https://github.com/quintoandar/hive-metastore-client/blob/main/thrift_files/source/hive_metastore.thrift) mapping.
+
+You should always call the `.build()` at the end to get the desired
+object.
+
+Some objects (like the Thrift `Table`) are more complex and requires other 
+objects as parameters.
+
+To learn more in practice use cases, see Hive Metastore Client's [examples](https://github.com/quintoandar/hive-metastore-client/tree/main/examples).

--- a/docs/source/builders.md
+++ b/docs/source/builders.md
@@ -1,19 +1,19 @@
 # Builders
 
-Willing to isolate its dependencies from users code, this library implements 
+In order to isolate its dependencies from users code, this library implements 
 the [builder pattern](https://refactoring.guru/design-patterns/builder/python/example).
 
 So instead of manually creating the Thrift objects for dealing with the
 Hive Metastore server, you can use the [builders](https://github.com/quintoandar/hive-metastore-client/tree/main/hive_metastore_client/builders).
 
 Each builder reflects the Thrift object's characteristics that it is building.
-For more information about the object particularities you can 
+For more information about the object particularities, you can 
 try finding more information in the [hive_metastore.thrift](https://github.com/quintoandar/hive-metastore-client/blob/main/thrift_files/source/hive_metastore.thrift) mapping.
 
 You should always call the `.build()` at the end to get the desired
 object.
 
-Some objects (like the Thrift `Table`) are more complex and requires other 
+Some objects (like the Thrift `Table`) are more complex and require other 
 objects as parameters.
 
-To learn more in practice use cases, see Hive Metastore Client's [examples](https://github.com/quintoandar/hive-metastore-client/tree/main/examples).
+To learn more in practice use cases, see Hive Metastore Client [examples](https://github.com/quintoandar/hive-metastore-client/tree/main/examples).

--- a/docs/source/getstarted.md
+++ b/docs/source/getstarted.md
@@ -2,7 +2,7 @@
 
 Hive Metastore Client depends on **Python 3.7+**.
 
-Python Package Index hosts reference to a pip-installable module of this library, using it is as straightforward as including it on your project's requirements.
+[Python Package Index](https://pypi.org/project/hive-metastore-client/) hosts reference to a pip-installable module of this library, using it is as straightforward as including it on your project's requirements.
 
 ```bash
 pip install hive-metastore-client
@@ -26,11 +26,9 @@ Click on the following links to open the [examples](https://github.com/quintoand
 
 **[#4 Add partitions to a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/add_partitions.py)**
 
-// TODO: Give examples and explain better how to use each Builder
-
 ## Available methods
 
-You can see all the Hive Metastore server available methods by looking the 
+You can see all the Hive Metastore server available methods by looking at the 
 interface:
 [`thrift_files.libraries.thrift_hive_metastore_client.ThriftHiveMetastore.Iface`](https://github.com/quintoandar/hive-metastore-client/blob/main/thrift_files/libraries/thrift_hive_metastore_client/ThriftHiveMetastore.py).
 

--- a/docs/source/getstarted.md
+++ b/docs/source/getstarted.md
@@ -16,7 +16,7 @@ pip install -r requirements.txt
 
 ## Discovering Hive Metastore Client
 
-Welcome to **Discovering Hive Metastore Client** tutorial series! Click on the following links to open the tutorials:
+Click on the following links to open the [examples](https://github.com/quintoandar/hive-metastore-client/tree/main/examples):
 
 **[#1 Create a database](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/create_database.py)**
 
@@ -24,4 +24,18 @@ Welcome to **Discovering Hive Metastore Client** tutorial series! Click on the f
 
 **[#3 Add columns to a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/add_columns_to_table.py)**
 
+**[#4 Add partitions to a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/add_partitions.py)**
+
 // TODO: Give examples and explain better how to use each Builder
+
+## Available methods
+
+You can see all the Hive Metastore server available methods by looking the 
+interface:
+[`thrift_files.libraries.thrift_hive_metastore_client.ThriftHiveMetastore.Iface`](https://github.com/quintoandar/hive-metastore-client/blob/main/thrift_files/libraries/thrift_hive_metastore_client/ThriftHiveMetastore.py).
+
+Beyond the default methods, this library also implements the methods below in
+the [`HiveMetastoreClient`](https://github.com/quintoandar/hive-metastore-client/blob/main/hive_metastore_client/hive_mestastore_client.py) class:
+
+- [`add_columns_to_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_mestastore_client.HiveMetastoreClient.add_columns_to_table)
+- [`add_partitions_to_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_mestastore_client.HiveMetastoreClient.add_columns_to_table)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,7 +15,7 @@ An example of how to use the library for running DML commands in hive metastore:
     with HiveMetastoreClient(HIVE_HOST, HIVE_PORT) as hive_metastore_client:
         hive_metastore_client.create_database(database)
 
-To learn more use cases in practice, see [Hive Metastore Client's examples](https://github.com/quintoandar/hive-metastore-client/blob/main/examples)
+To learn more use cases in practice, see `Hive Metastore Client's examples <https://github.com/quintoandar/hive-metastore-client/blob/main/examples>`_
 
 
 Navigation
@@ -25,4 +25,6 @@ Navigation
    :maxdepth: 2
 
    getstarted
+   thrift_instructions
+   builders
    modules

--- a/docs/source/thrift_instructions.md
+++ b/docs/source/thrift_instructions.md
@@ -1,0 +1,37 @@
+# About Thrift
+
+This project uses the Thrift mapping files and the Thrift package to auto 
+generate the python libraries that you can find in `thrift_files/libraries/`.
+
+## Updating the Thrift Hive Metastore client
+
+### Requirements
+
+#### The thrift service mapping 
+Download the _hive_metastore.thrift_ (and its required thrift files if any. 
+Then place them in the same directory).
+
+These two files are the mapping for the Thrift Service that the Hive Metastore is built on: 
+- [hive_metastore.thrift](https://github.com/apache/hive/blob/branch-3.0/standalone-metastore/src/main/thrift/hive_metastore.thrift)
+- [fb303.thrift](https://github.com/apache/thrift/blob/master/contrib/fb303/if/fb303.thrift)
+
+We are using the Hive Metastore version 3.0 ([branch-3.0](https://github.com/apache/hive/tree/branch-3.0/standalone-metastore))
+
+#### Thrift package
+ 
+1 - First you need to install the thrift package so you can "compile" the thrift file into python code. 
+You can refer to these tutorial for installing it: https://thrift-tutorial.readthedocs.io/en/latest/installation.html. 
+We used the latest version (0.14.0) of the Thrift package.
+
+2 - After installing thrift package, you should open the directory where the _hive_metastore.thrift_ (and others) is 
+placed and run:
+```shell
+thrift --gen py hive_metastore.thrift
+thrift --gen py fb303.thrift
+```
+
+3 - Now you have the new python code generated inside `gen-py`. Extract the classes and place them in the right 
+directories - we use `thrift_files/libraries/` for these generate libraries.
+
+4 - The generated files are huge, therefore be sure that the generated files directory names are ignored in the make 
+commands _style-check_ and _apply-lint_. So these files are not evaluated during the checks.

--- a/thrift_files/readme.md
+++ b/thrift_files/readme.md
@@ -17,7 +17,7 @@ We are using the Hive Metastore version 3.0 ([branch-3.0](https://github.com/apa
 You can refer to these tutorial for installing it: https://thrift-tutorial.readthedocs.io/en/latest/installation.html. We used the Thrift latest version (0.14.0)
 
 2 - After installing thrift cli, you should open the directory where the _hive_metastore.thrift_ (and others) is placed and run:
-```shell script
+```shell
 thrift --gen py hive_metastore.thrift
 thrift --gen py fb303.thrift
 ```


### PR DESCRIPTION
## Why? :open_book:
We want to give some clear information about how the project works.

## What? :wrench:
- add doc pages about Thrift and Builders
- update methods information