### PR TITLE
Update client import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Hive Metastore Client
-_A client for connecting and running DMLs on [Hive](https://hive.apache.org/) Metastore using [Thrift](https://thrift.apache.org/) protocol._
+_A client for connecting and running DDLs on [Hive](https://hive.apache.org/) Metastore using [Thrift](https://thrift.apache.org/) protocol._
 
 [![Release](https://img.shields.io/github/v/release/quintoandar/hive-metastore-client)]((https://pypi.org/project/hive-metastore-client/))
 ![Python Version](https://img.shields.io/badge/python-3.7%20%7C%203.8-brightgreen.svg)
@@ -19,7 +19,7 @@ This library supports Python version 3.7+.
 
 To check library main features you can check [Hive Metastore Client's Documentation](https://hive-metastore-client.readthedocs.io/en/latest/), which is hosted by Read the Docs.
 
-An example of how to use the library for running DML commands in hive metastore:
+An example of how to use the library for running DDL commands in hive metastore:
 
 ```python
 from hive_metastore_client.builders import DatabaseBuilder

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ An example of how to use the library for running DML commands in hive metastore:
 
 ```python
 from hive_metastore_client.builders import DatabaseBuilder
-from hive_metastore_client.hive_mestastore_client import HiveMetastoreClient
+from hive_metastore_client import HiveMetastoreClient
 
 database = DatabaseBuilder(name='new_db').build()
 with HiveMetastoreClient(HIVE_HOST, HIVE_PORT) as hive_metastore_client:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To check library main features you can check [Hive Metastore Client's Documentat
 An example of how to use the library for running DML commands in hive metastore:
 
 ```python
-from hive_metastore_client.builders.database_builder import DatabaseBuilder
+from hive_metastore_client.builders import DatabaseBuilder
 from hive_metastore_client.hive_mestastore_client import HiveMetastoreClient
 
 database = DatabaseBuilder(name='new_db').build()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,7 @@ An example of how to use the library for running DML commands in hive metastore:
 .. code-block:: python
 
     from hive_metastore_client.builders import DatabaseBuilder
-    from hive_metastore_client.hive_mestastore_client import HiveMetastoreClient
+    from hive_metastore_client import HiveMetastoreClient
 
     database = DatabaseBuilder(name='new_db').build()
     with HiveMetastoreClient(HIVE_HOST, HIVE_PORT) as hive_metastore_client:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,9 +2,9 @@ Hive Metastore Client
 =====================
 Made with |:heart:| by the **Data Engineering** team from `QuintoAndar <https://github.com/quintoandar/>`_.
 
-A client for connecting and running DMLs on Hive Metastore using Thrift protocol.
+A client for connecting and running DDLs on Hive Metastore using Thrift protocol.
 
-An example of how to use the library for running DML commands in hive metastore:
+An example of how to use the library for running commands in hive metastore:
 
 .. code-block:: python
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ An example of how to use the library for running DML commands in hive metastore:
 
 .. code-block:: python
 
-    from hive_metastore_client.builders.database_builder import DatabaseBuilder
+    from hive_metastore_client.builders import DatabaseBuilder
     from hive_metastore_client.hive_mestastore_client import HiveMetastoreClient
 
     database = DatabaseBuilder(name='new_db').build()

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ guarantees that the connection will be automatically opened and closed for you.
 I.g.:
 ```python
 from hive_metastore_client.hive_mestastore_client import HiveMetastoreClient
-from hive_metastore_client.builders.database_builder import DatabaseBuilder
+from hive_metastore_client.builders import DatabaseBuilder
 
 database = DatabaseBuilder(name='new_db').build()
 with HiveMetastoreClient(HIVE_HOST, HIVE_PORT) as hive_metastore_client:

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@ It is necessary to use the client instance with the `with` statement, this
 guarantees that the connection will be automatically opened and closed for you.
 I.g.:
 ```python
-from hive_metastore_client.hive_mestastore_client import HiveMetastoreClient
+from hive_metastore_client import HiveMetastoreClient
 from hive_metastore_client.builders import DatabaseBuilder
 
 database = DatabaseBuilder(name='new_db').build()

--- a/examples/add_columns_to_table.py
+++ b/examples/add_columns_to_table.py
@@ -5,7 +5,7 @@
 """
 
 from hive_metastore_client.builders.column_builder import ColumnBuilder
-from hive_metastore_client.hive_mestastore_client import HiveMetastoreClient
+from hive_metastore_client import HiveMetastoreClient
 
 HIVE_HOST = "<ADD_HIVE_HOST_HERE>"
 HIVE_PORT = 9083

--- a/examples/add_columns_to_table.py
+++ b/examples/add_columns_to_table.py
@@ -4,7 +4,7 @@
     Check Builder constructor for more information.
 """
 
-from hive_metastore_client.builders.column_builder import ColumnBuilder
+from hive_metastore_client.builders import ColumnBuilder
 from hive_metastore_client import HiveMetastoreClient
 
 HIVE_HOST = "<ADD_HIVE_HOST_HERE>"

--- a/examples/add_partitions.py
+++ b/examples/add_partitions.py
@@ -1,5 +1,5 @@
 from hive_metastore_client.builders import PartitionBuilder
-from hive_metastore_client.hive_mestastore_client import HiveMetastoreClient
+from hive_metastore_client import HiveMetastoreClient
 
 HIVE_HOST = "<ADD_HIVE_HOST_HERE>"
 HIVE_PORT = 9083

--- a/examples/create_database.py
+++ b/examples/create_database.py
@@ -5,7 +5,7 @@
 """
 
 from hive_metastore_client.builders.database_builder import DatabaseBuilder
-from hive_metastore_client.hive_mestastore_client import HiveMetastoreClient
+from hive_metastore_client import HiveMetastoreClient
 
 HIVE_HOST = "<ADD_HIVE_HOST_HERE>"
 HIVE_PORT = 9083

--- a/examples/create_database.py
+++ b/examples/create_database.py
@@ -4,7 +4,7 @@
     Check Builder constructor for more information.
 """
 
-from hive_metastore_client.builders.database_builder import DatabaseBuilder
+from hive_metastore_client.builders import DatabaseBuilder
 from hive_metastore_client import HiveMetastoreClient
 
 HIVE_HOST = "<ADD_HIVE_HOST_HERE>"

--- a/examples/create_table.py
+++ b/examples/create_table.py
@@ -11,7 +11,7 @@ from hive_metastore_client.builders.storage_descriptor_builder import (
     StorageDescriptorBuilder,
 )
 from hive_metastore_client.builders.table_builder import TableBuilder
-from hive_metastore_client.hive_mestastore_client import HiveMetastoreClient
+from hive_metastore_client import HiveMetastoreClient
 
 HIVE_HOST = "<ADD_HIVE_HOST_HERE>"
 HIVE_PORT = 9083

--- a/examples/create_table.py
+++ b/examples/create_table.py
@@ -10,7 +10,7 @@ from hive_metastore_client.builders.serde_info_builder import SerDeInfoBuilder
 from hive_metastore_client.builders.storage_descriptor_builder import (
     StorageDescriptorBuilder,
 )
-from hive_metastore_client.builders.table_builder import TableBuilder
+from hive_metastore_client.builders import TableBuilder
 from hive_metastore_client import HiveMetastoreClient
 
 HIVE_HOST = "<ADD_HIVE_HOST_HERE>"

--- a/hive_metastore_client/__init__.py
+++ b/hive_metastore_client/__init__.py
@@ -1,1 +1,2 @@
 """Hive Metastore Client."""
+from hive_metastore_client.hive_mestastore_client import HiveMetastoreClient

--- a/tests/unit/hive_metastore_client/conftest.py
+++ b/tests/unit/hive_metastore_client/conftest.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from hive_metastore_client.hive_mestastore_client import HiveMetastoreClient
+from hive_metastore_client import HiveMetastoreClient
 
 
 @pytest.fixture

--- a/tests/unit/hive_metastore_client/test_hive_mestastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_mestastore_client.py
@@ -2,7 +2,7 @@ from unittest import mock
 from unittest.mock import Mock
 
 import pytest
-from hive_metastore_client.hive_mestastore_client import HiveMetastoreClient
+from hive_metastore_client import HiveMetastoreClient
 
 
 class TestHiveMetastoreClient:


### PR DESCRIPTION
## Why? :open_book:
We want to let the import path simpler for lib users.

## What? :wrench:
Add HiveMetastoreClient import in init.
Now the users can import with:
```python
from hive_metastore_client import HiveMetastoreClient
```
instead of:
```python
from hive_metastore_client.hive_metastore_client import HiveMetastoreClient
```

## Type of change :file_cabinet:

- [X] New feature (non-breaking change which adds functionality)

## How everything was tested? :straight_ruler:
With unit-tests + running individual scripts

## Checklist :memo:
- [x] I have added labels to distinguish the type of pull request.
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] I have made sure that new and existing unit tests pass locally with my changes;

