### PR TITLE
Adjusting docker image path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.ref == 'refs/heads/main' || contains(github.ref, 'hotfix/')
 
     runs-on: ubuntu-16.04
-    container: rafaelleinio/docker-java-python
+    container: quintoandar/python-3-7-java
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: "Test"
 on:
   push:
     branches:
+      - update-docker-path
       - main
       - hotfix/**
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   Pipeline:
     runs-on: ubuntu-16.04
-    container: rafaelleinio/docker-java-python
+    container: quintoandar/python-3-7-java
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ name: "Test"
 on:
   push:
     branches:
-      - update-docker-path
       - main
       - hotfix/**
   pull_request:


### PR DESCRIPTION
## Why? :open_book:
It is better to centralize the docker image to a well supported image, instead of the ones from individual contributors across the web.

## What? :wrench:
Shifting the docker image used by the project actions - flow.

## How everything was tested? :straight_ruler:
Ran 'test' workflow for the current branch and it ran smoothly.

## Checklist :memo:
- [X] I have added labels to distinguish the type of pull request.
- [X] I have performed a self-review of my own code;
- [X] I have made sure that new and existing unit tests pass locally with my changes;