### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 
 Preferably use **Added**, **Changed**, **Removed** and **Fixed** topics in each release or unreleased log for a better organization.
 
+## [1.0.1](https://github.com/quintoandar/hive-metastore-client/releases/tag/1.0.1)
+### Added
+* Added drop_columns_from_table method ([#30](https://github.com/quintoandar/hive-metastore-client/pull/30))
+### Changed
+* Updated imports in project ([#27](https://github.com/quintoandar/hive-metastore-client/pull/27))
+* Shifted to quintoandar's docker image ([#28](https://github.com/quintoandar/hive-metastore-client/pull/28))
+### Fixed
+* Fixed typo in the client's filename ([#33](https://github.com/quintoandar/hive-metastore-client/pull/33))
+
 ## [1.0.0](https://github.com/quintoandar/hive-metastore-client/releases/tag/1.0.0)
 First modules and entities of Hive Metastore Client package.
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 __package_name__ = "hive_metastore_client"
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __repository_url__ = "https://github.com/quintoandar/hive-metastore-client"
 
 with open("requirements.txt") as f:
@@ -12,7 +12,7 @@ with open("README.md") as f:
 
 setup(
     name=__package_name__,
-    description="A client for connecting and running DMLs on Hive Metastore with Thrift protocol",
+    description="A client for connecting and running DDLs on Hive Metastore with Thrift protocol",
     long_description=long_description,
     long_description_content_type="text/markdown",
     keywords="hive hive-metastore hive-client hive-metastore-client metastore",


### PR DESCRIPTION
## Why? :open_book:
Releasing version 1.0.1

## What? :wrench:
Main commits for this minor release:
- #33 - Typo fix (according to issue  #31 )
- #30 - Adding drop_columns_from_table method
- #28 - Shifting to quintoandar's docker image
- #27 - Updating imports

## Type of change :file_cabinet:
- [X] Release

## Checklist :memo:
- [X] I have added labels to distinguish the type of pull request.
- [X] I have performed a self-review of my own code;
- [X] I have made corresponding changes to the documentation;