### PR TITLE
[DF-324] Add create_database_if_not_exists method

### DIFF
--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -1,8 +1,10 @@
 """Hive Metastore Client main class."""
+import copy
+import logging
+from typing import List, Any
+
 from thrift.protocol import TBinaryProtocol
 from thrift.transport import TSocket, TTransport
-from typing import List, Any
-import copy
 
 from thrift_files.libraries.thrift_hive_metastore_client.ThriftHiveMetastore import (  # type: ignore # noqa: E501
     Client as ThriftClient,
@@ -11,7 +13,11 @@ from thrift_files.libraries.thrift_hive_metastore_client.ttypes import (  # type
     StorageDescriptor,
     Partition,
     FieldSchema,
+    Database,
+    AlreadyExistsException,
 )
+
+logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)
 
 
 class HiveMetastoreClient(ThriftClient):
@@ -129,6 +135,21 @@ class HiveMetastoreClient(ThriftClient):
         )
 
         self.add_partitions(partition_list_with_correct_location)
+
+    def create_database_if_not_exists(self, database: Database) -> None:
+        """
+        Creates the table in Hive Metastore if it does not exist.
+
+        Since hive metastore server and thrift mapping do not have the option
+         of checking if the database does not exist, this method simulates this
+         this behavior.
+
+        :param database: the database object
+        """
+        try:
+            self.create_database(database)
+        except AlreadyExistsException as e:
+            logging.info(f"m=create_database_if_not_exists, msg={e.message}")
 
     @staticmethod
     def _format_partitions_location(

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -1,6 +1,5 @@
 """Hive Metastore Client main class."""
 import copy
-import logging
 from typing import List, Any
 
 from thrift.protocol import TBinaryProtocol
@@ -16,8 +15,6 @@ from thrift_files.libraries.thrift_hive_metastore_client.ttypes import (  # type
     Database,
     AlreadyExistsException,
 )
-
-logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)
 
 
 class HiveMetastoreClient(ThriftClient):
@@ -136,7 +133,7 @@ class HiveMetastoreClient(ThriftClient):
 
         self.add_partitions(partition_list_with_correct_location)
 
-    def create_database_if_not_exists(self, database: Database) -> None:
+    def create_database_if_not_exists(self, database: Database) -> bool:
         """
         Creates the table in Hive Metastore if it does not exist.
 
@@ -148,8 +145,9 @@ class HiveMetastoreClient(ThriftClient):
         """
         try:
             self.create_database(database)
-        except AlreadyExistsException as e:
-            logging.info(f"m=create_database_if_not_exists, msg={e.message}")
+            return True
+        except AlreadyExistsException:
+            return False
 
     @staticmethod
     def _format_partitions_location(

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -212,32 +212,34 @@ class TestHiveMetastoreClient:
         assert returned_value[0].sd.location == expected_location
 
     @mock.patch.object(HiveMetastoreClient, "create_database")
-    @mock.patch("hive_metastore_client.hive_metastore_client.logging")
     def test_create_database_if_not_exists_with_nonexistent_database(
-        self, mocked_logging, mocked_create_database, hive_metastore_client,
+        self, mocked_create_database, hive_metastore_client,
     ):
         # arrange
         mocked_database_obj = Mock()
 
         # act
-        hive_metastore_client.create_database_if_not_exists(mocked_database_obj)
+        return_value = hive_metastore_client.create_database_if_not_exists(
+            mocked_database_obj
+        )
 
         # assert
+        assert return_value
         mocked_create_database.assert_called_once_with(mocked_database_obj)
-        mocked_logging.info.assert_not_called()
 
     @mock.patch.object(HiveMetastoreClient, "create_database")
-    @mock.patch("hive_metastore_client.hive_metastore_client.logging")
     def test_create_database_if_not_exists_with_existent_database(
-        self, mocked_logging, mocked_create_database, hive_metastore_client,
+        self, mocked_create_database, hive_metastore_client,
     ):
         # arrange
         mocked_database_obj = Mock()
         mocked_create_database.side_effect = AlreadyExistsException()
 
         # act
-        hive_metastore_client.create_database_if_not_exists(mocked_database_obj)
+        return_value = hive_metastore_client.create_database_if_not_exists(
+            mocked_database_obj
+        )
 
         # assert
+        assert not return_value
         mocked_create_database.assert_called_once_with(mocked_database_obj)
-        mocked_logging.info.assert_called_once()

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -2,8 +2,16 @@ from unittest import mock
 from unittest.mock import Mock
 
 import pytest
+
 from hive_metastore_client import HiveMetastoreClient
-from thrift_files.libraries.thrift_hive_metastore_client.ttypes import FieldSchema
+from thrift_files.libraries.thrift_hive_metastore_client.ThriftHiveMetastore import (
+    Client as ThriftClient,
+)
+from thrift_files.libraries.thrift_hive_metastore_client.ttypes import (
+    FieldSchema,
+    NoSuchObjectException,
+    AlreadyExistsException,
+)
 
 
 class TestHiveMetastoreClient:
@@ -202,3 +210,34 @@ class TestHiveMetastoreClient:
         # assert
         assert mocked_validate_lists_length.call_count == 1
         assert returned_value[0].sd.location == expected_location
+
+    @mock.patch.object(HiveMetastoreClient, "create_database")
+    @mock.patch("hive_metastore_client.hive_metastore_client.logging")
+    def test_create_database_if_not_exists_with_nonexistent_database(
+        self, mocked_logging, mocked_create_database, hive_metastore_client,
+    ):
+        # arrange
+        mocked_database_obj = Mock()
+
+        # act
+        hive_metastore_client.create_database_if_not_exists(mocked_database_obj)
+
+        # assert
+        mocked_create_database.assert_called_once_with(mocked_database_obj)
+        mocked_logging.info.assert_not_called()
+
+    @mock.patch.object(HiveMetastoreClient, "create_database")
+    @mock.patch("hive_metastore_client.hive_metastore_client.logging")
+    def test_create_database_if_not_exists_with_existent_database(
+        self, mocked_logging, mocked_create_database, hive_metastore_client,
+    ):
+        # arrange
+        mocked_database_obj = Mock()
+        mocked_create_database.side_effect = AlreadyExistsException()
+
+        # act
+        hive_metastore_client.create_database_if_not_exists(mocked_database_obj)
+
+        # assert
+        mocked_create_database.assert_called_once_with(mocked_database_obj)
+        mocked_logging.info.assert_called_once()


### PR DESCRIPTION
## Why? :open_book:
We don't have an option to create a database only if it doesn't exist in the Metastore Server. So this PR creates the create_database_if_not_exists method, simulating this behavior.

## What? :wrench:
- add method `create_database_if_not_exists` and tests

## Type of change :file_cabinet:
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How everything was tested? :straight_ruler:
Unit tests + manual test with server

## Checklist :memo:
- [X] I have added labels to distinguish the type of pull request.
- [X] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [X] I have performed a self-review of my own code;
- [X] I have made corresponding changes to the documentation;
- [X] I have added tests that prove my fix is effective or that my feature works;
- [X] I have made sure that new and existing unit tests pass locally with my changes;

