### PR TITLE
[DAE-63] Handling exception when adding duplicate partitions

### DIFF
--- a/docs/source/getstarted.md
+++ b/docs/source/getstarted.md
@@ -37,4 +37,4 @@ the [`HiveMetastoreClient`](https://github.com/quintoandar/hive-metastore-client
 
 - [`add_columns_to_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.add_columns_to_table)
 - [`drop_columns_from_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.drop_columns_from_table)
-- [`add_partitions_if_not_exists`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.add_columns_to_table)
+- [`add_partitions_if_not_exists`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.add_partitions_if_not_exists)

--- a/docs/source/getstarted.md
+++ b/docs/source/getstarted.md
@@ -36,4 +36,5 @@ Beyond the default methods, this library also implements the methods below in
 the [`HiveMetastoreClient`](https://github.com/quintoandar/hive-metastore-client/blob/main/hive_metastore_client/hive_metastore_client.py) class:
 
 - [`add_columns_to_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.add_columns_to_table)
-- [`add_partitions_to_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.add_columns_to_table)
+- [`drop_columns_from_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.drop_columns_from_table)
+- [`add_partitions_if_not_exists`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.add_columns_to_table)

--- a/examples/add_partitions.py
+++ b/examples/add_partitions.py
@@ -20,4 +20,4 @@ partition_list = [
 
 with HiveMetastoreClient(HIVE_HOST, HIVE_PORT) as hive_client:
     # Adding two set of partitions to specified table
-    hive_client.add_partitions_to_table(DATABASE_NAME, TABLE_NAME, partition_list)
+    hive_client.add_partitions_if_not_exists(DATABASE_NAME, TABLE_NAME, partition_list)

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -119,10 +119,20 @@ class HiveMetastoreClient(ThriftClient):
         """
         Add partitions to a table.
 
+        If the user tries to add a partition twice, the method handles the
+         AlreadyExistsException returning false and indicating the operation
+         result: True for new partition values added or False when nothing
+         was done.
+
         :param db_name: database name where the table is at
         :param table_name: table name which the partitions belong to
         :param partition_list: list of partitions to be added to the table
         """
+        if not partition_list:
+            raise ValueError(
+                "m=add_partitions_to_table, msg=The partition list is empty."
+            )
+
         table = self.get_table(dbname=db_name, tbl_name=table_name)
 
         partition_list_with_correct_location = self._format_partitions_location(
@@ -202,4 +212,6 @@ class HiveMetastoreClient(ThriftClient):
         :param list_b: second list to be compared
         """
         if len(list_a) != len(list_b):
-            raise ValueError("The length of the two provided lists does not match")
+            raise ValueError(
+                "m=_validate_lists_length, msg=The length of the two provided lists does not match"
+            )

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -115,7 +115,7 @@ class HiveMetastoreClient(ThriftClient):
 
     def add_partitions_to_table(
         self, db_name: str, table_name: str, partition_list: List[Partition]
-    ) -> None:
+    ) -> bool:
         """
         Add partitions to a table.
 
@@ -131,7 +131,11 @@ class HiveMetastoreClient(ThriftClient):
             table_partition_keys=table.partitionKeys,
         )
 
-        self.add_partitions(partition_list_with_correct_location)
+        try:
+            self.add_partitions(partition_list_with_correct_location)
+            return True
+        except AlreadyExistsException:
+            return False
 
     def create_database_if_not_exists(self, database: Database) -> bool:
         """

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -120,9 +120,7 @@ class HiveMetastoreClient(ThriftClient):
         Add partitions to a table if it does not exist.
 
         If the user tries to add a partition twice, the method handles the
-         AlreadyExistsException returning false and indicating the operation
-         result: True for new partition values added or False when nothing
-         was done.
+         AlreadyExistsException, not raising an error.
 
         :param db_name: database name where the table is at
         :param table_name: table name which the partitions belong to

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -1,5 +1,6 @@
 """Hive Metastore Client main class."""
 import copy
+import logging
 from typing import List, Any
 
 from thrift.protocol import TBinaryProtocol
@@ -15,6 +16,8 @@ from thrift_files.libraries.thrift_hive_metastore_client.ttypes import (  # type
     Database,
     AlreadyExistsException,
 )
+
+logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)
 
 
 class HiveMetastoreClient(ThriftClient):
@@ -144,7 +147,8 @@ class HiveMetastoreClient(ThriftClient):
         try:
             self.add_partitions(partition_list_with_correct_location)
             return True
-        except AlreadyExistsException:
+        except AlreadyExistsException as e:
+            logging.info(f"m=add_partitions_to_table, msg={e.message}")
             return False
 
     def create_database_if_not_exists(self, database: Database) -> bool:
@@ -160,7 +164,8 @@ class HiveMetastoreClient(ThriftClient):
         try:
             self.create_database(database)
             return True
-        except AlreadyExistsException:
+        except AlreadyExistsException as e:
+            logging.info(f"m=create_database_if_not_exists, msg={e.message}")
             return False
 
     @staticmethod

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -174,12 +174,11 @@ class TestHiveMetastoreClient:
         mocked__format_partitions.return_value = formatted_partitions_location
 
         # act
-        returned_value = hive_metastore_client.add_partitions_to_table(
+        hive_metastore_client.add_partitions_if_not_exists(
             db_name=db_name, table_name=table_name, partition_list=mocked_partition_list
         )
 
         # assert
-        assert returned_value
         mocked_get_table.assert_called_once_with(dbname=db_name, tbl_name=table_name)
         mocked__format_partitions.assert_called_once_with(
             partition_list=mocked_partition_list,
@@ -212,12 +211,11 @@ class TestHiveMetastoreClient:
         mocked_add_partitions.side_effect = AlreadyExistsException()
 
         # act
-        returned_value = hive_metastore_client.add_partitions_to_table(
+        hive_metastore_client.add_partitions_if_not_exists(
             db_name=db_name, table_name=table_name, partition_list=mocked_partition_list
         )
 
         # assert
-        assert not returned_value
         mocked_get_table.assert_called_once_with(dbname=db_name, tbl_name=table_name)
         mocked__format_partitions.assert_called_once_with(
             partition_list=mocked_partition_list,
@@ -239,7 +237,7 @@ class TestHiveMetastoreClient:
         # assert
         with raises(ValueError):
             # act
-            hive_metastore_client.add_partitions_to_table(
+            hive_metastore_client.add_partitions_if_not_exists(
                 db_name=ANY, table_name=ANY, partition_list=[]
             )
         mocked_get_table.assert_not_called()

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -1,7 +1,8 @@
 from unittest import mock
-from unittest.mock import Mock
+from unittest.mock import Mock, ANY
 
 import pytest
+from pytest import raises
 
 from hive_metastore_client import HiveMetastoreClient
 from thrift_files.libraries.thrift_hive_metastore_client.ThriftHiveMetastore import (
@@ -224,6 +225,26 @@ class TestHiveMetastoreClient:
             table_partition_keys=mocked_table.partitionKeys,
         )
         mocked_add_partitions.assert_called_once_with(formatted_partitions_location)
+
+    @mock.patch.object(HiveMetastoreClient, "get_table")
+    @mock.patch.object(HiveMetastoreClient, "_format_partitions_location")
+    @mock.patch.object(HiveMetastoreClient, "add_partitions")
+    def test_add_partitions_to_table_with_invalid_partitions(
+        self,
+        mocked_add_partitions,
+        mocked__format_partitions,
+        mocked_get_table,
+        hive_metastore_client,
+    ):
+        # assert
+        with raises(ValueError):
+            # act
+            hive_metastore_client.add_partitions_to_table(
+                db_name=ANY, table_name=ANY, partition_list=[]
+            )
+        mocked_get_table.assert_not_called()
+        mocked__format_partitions.assert_not_called()
+        mocked_add_partitions.assert_not_called()
 
     @mock.patch.object(HiveMetastoreClient, "_validate_lists_length")
     def test_format_partitions_location(

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -191,11 +191,11 @@ class TestHiveMetastoreClient:
     @mock.patch.object(HiveMetastoreClient, "_format_partitions_location")
     @mock.patch.object(HiveMetastoreClient, "add_partitions")
     def test_add_partitions_to_table_with_duplicated_partitions(
-            self,
-            mocked_add_partitions,
-            mocked__format_partitions,
-            mocked_get_table,
-            hive_metastore_client,
+        self,
+        mocked_add_partitions,
+        mocked__format_partitions,
+        mocked_get_table,
+        hive_metastore_client,
     ):
         # arrange
         db_name = "database_name"


### PR DESCRIPTION
## Why? :open_book:
The server raises an AlreadyExistsException when some partition is added twice.
We want the client doesn't raise an error in this case: if some partition already exists then nothing should be done.
This will make the code cleaner for libs users that don't need to handle errors on their side.

## What? :wrench:
- add a try block for add_partitions_to_table

## Type of change :file_cabinet:
- [X] enhancement (non-breaking change)
- [X] This change requires a documentation update

## How everything was tested? :straight_ruler:
Unit tests

## Checklist :memo:
- [x] I have added labels to distinguish the type of pull request.
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] I have made sure that new and existing unit tests pass locally with my changes;

