### PR TITLE
[DAE-63] Remove method returning for create_database_if_not_exists

### DIFF
--- a/docs/source/getstarted.md
+++ b/docs/source/getstarted.md
@@ -36,5 +36,5 @@ Beyond the default methods, this library also implements the methods below in
 the [`HiveMetastoreClient`](https://github.com/quintoandar/hive-metastore-client/blob/main/hive_metastore_client/hive_metastore_client.py) class:
 
 - [`add_columns_to_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.add_columns_to_table)
-- [`add_partitions_to_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.add_columns_to_table)
+- [`add_partitions_to_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.add_partitions_to_table)
 - [`create_database_if_not_exists`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.create_database_if_not_exists)

--- a/docs/source/getstarted.md
+++ b/docs/source/getstarted.md
@@ -37,3 +37,4 @@ the [`HiveMetastoreClient`](https://github.com/quintoandar/hive-metastore-client
 
 - [`add_columns_to_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.add_columns_to_table)
 - [`add_partitions_to_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.add_columns_to_table)
+- [`create_database_if_not_exists`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.create_database_if_not_exists)

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -133,7 +133,7 @@ class HiveMetastoreClient(ThriftClient):
 
         self.add_partitions(partition_list_with_correct_location)
 
-    def create_database_if_not_exists(self, database: Database) -> bool:
+    def create_database_if_not_exists(self, database: Database) -> None:
         """
         Creates the table in Hive Metastore if it does not exist.
 
@@ -145,9 +145,8 @@ class HiveMetastoreClient(ThriftClient):
         """
         try:
             self.create_database(database)
-            return True
         except AlreadyExistsException:
-            return False
+            pass
 
     @staticmethod
     def _format_partitions_location(

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -219,12 +219,9 @@ class TestHiveMetastoreClient:
         mocked_database_obj = Mock()
 
         # act
-        return_value = hive_metastore_client.create_database_if_not_exists(
-            mocked_database_obj
-        )
+        hive_metastore_client.create_database_if_not_exists(mocked_database_obj)
 
         # assert
-        assert return_value
         mocked_create_database.assert_called_once_with(mocked_database_obj)
 
     @mock.patch.object(HiveMetastoreClient, "create_database")
@@ -236,10 +233,7 @@ class TestHiveMetastoreClient:
         mocked_create_database.side_effect = AlreadyExistsException()
 
         # act
-        return_value = hive_metastore_client.create_database_if_not_exists(
-            mocked_database_obj
-        )
+        hive_metastore_client.create_database_if_not_exists(mocked_database_obj)
 
         # assert
-        assert not return_value
         mocked_create_database.assert_called_once_with(mocked_database_obj)


### PR DESCRIPTION
## Why? :open_book:
We decided that the returning could lead to a misunderstanding of the method, so we'll remove it

## What? :wrench:
- remove returning for method `create_database_if_not_exists`

## Type of change :file_cabinet:
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How everything was tested? :straight_ruler:
- Unit tests

## Checklist :memo:
- [x] I have added labels to distinguish the type of pull request.
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] I have made sure that new and existing unit tests pass locally with my changes;

## Attention Points :warning:
_Replace me for what the reviewer will need to pay attention to in the PR or just to cover any concerns after the merge._
