### PR TITLE
[DAE-92] Add method create_external_table

### DIFF
--- a/docs/source/getstarted.md
+++ b/docs/source/getstarted.md
@@ -22,9 +22,11 @@ Click on the following links to open the [examples](https://github.com/quintoand
 
 **[#2 Create a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/create_table.py)**
 
-**[#3 Add columns to a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/add_columns_to_table.py)**
+**[#3 Create an external table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/create_external_table.py)**
 
-**[#4 Add partitions to a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/add_partitions.py)**
+**[#4 Add columns to a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/add_columns_to_table.py)**
+
+**[#5 Add partitions to a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/add_partitions.py)**
 
 ## Available methods
 

--- a/docs/source/getstarted.md
+++ b/docs/source/getstarted.md
@@ -39,3 +39,4 @@ the [`HiveMetastoreClient`](https://github.com/quintoandar/hive-metastore-client
 - [`drop_columns_from_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.drop_columns_from_table)
 - [`add_partitions_if_not_exists`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.add_partitions_if_not_exists)
 - [`create_database_if_not_exists`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.create_database_if_not_exists)
+- [`create_external_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.create_external_table)

--- a/examples/create_external_table.py
+++ b/examples/create_external_table.py
@@ -4,8 +4,10 @@
     Some arguments are optional when creating a thrift object.
     Check each Builder constructor for more information.
 
-    Note: if you want to create an external table refer to the
-     example create_external_table.py.
+    Due to a bug in Hive Metastore server we need to enforce the parameter
+     EXTERNAL=TRUE when creating an external table. You can either use the
+     method `create_external_table` with the table object or declare the two
+     table parameters before calling the method create_table.
 """
 
 from hive_metastore_client import HiveMetastoreClient
@@ -60,4 +62,4 @@ table = TableBuilder(
 
 with HiveMetastoreClient(HIVE_HOST, HIVE_PORT) as hive_metastore_client:
     # Creating new table from thrift table object
-    hive_metastore_client.create_table(table)
+    hive_metastore_client.create_external_table(table)

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -164,7 +164,7 @@ class HiveMetastoreClient(ThriftClient):
         """
         Creates an external table in Hive Metastore.
 
-        When it is created a table with default tableType (None) or equal to
+        When a table is created with tableType default (None) or equal to
          EXTERNAL_TABLE there is an error in the server that creates the table
          as a MANAGED_TABLE.
         This method enforces the parameter EXTERNAL=TRUE so the table is

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -14,6 +14,7 @@ from thrift_files.libraries.thrift_hive_metastore_client.ttypes import (  # type
     FieldSchema,
     Database,
     AlreadyExistsException,
+    Table,
 )
 
 
@@ -158,6 +159,22 @@ class HiveMetastoreClient(ThriftClient):
             self.create_database(database)
         except AlreadyExistsException:
             pass
+
+    def create_external_table(self, table: Table) -> None:
+        """
+        Creates an external table in Hive Metastore.
+
+        When it is created a table with default tableType (None) or equal to
+         EXTERNAL_TABLE there is an error in the server that creates the table
+         as a MANAGED_TABLE.
+        This method enforces the parameter EXTERNAL=TRUE so the table is
+         created correctly.
+
+        :param table: the table object
+        """
+        table.parameters = {"EXTERNAL": "TRUE"}
+        table.tableType = "EXTERNAL_TABLE"
+        self.create_table(table)
 
     @staticmethod
     def _format_partitions_location(

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -311,9 +311,9 @@ class TestHiveMetastoreClient:
         updated_table = copy(table)
         updated_table.parameters = {"EXTERNAL": "TRUE"}
         updated_table.tableType = "EXTERNAL_TABLE"
+
         # act
         hive_metastore_client.create_external_table(table)
 
         # assert
-        assert table.parameters == updated_table.parameters
         mocked_create_table.assert_called_once_with(updated_table)

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -1,3 +1,4 @@
+from copy import copy
 from unittest import mock
 from unittest.mock import Mock, ANY
 
@@ -5,6 +6,7 @@ import pytest
 from pytest import raises
 
 from hive_metastore_client import HiveMetastoreClient
+from hive_metastore_client.builders import TableBuilder
 from thrift_files.libraries.thrift_hive_metastore_client.ThriftHiveMetastore import (
     Client as ThriftClient,
 )
@@ -295,3 +297,23 @@ class TestHiveMetastoreClient:
 
         # assert
         mocked_create_database.assert_called_once_with(mocked_database_obj)
+
+    @mock.patch.object(HiveMetastoreClient, "create_table")
+    def test_create_external_table(self, mocked_create_table, hive_metastore_client):
+        # arrange
+        table = TableBuilder(
+            table_name="table_name",
+            db_name="database_name",
+            owner="owner",
+            storage_descriptor=Mock(),
+            partition_keys=[],
+        ).build()
+        updated_table = copy(table)
+        updated_table.parameters = {"EXTERNAL": "TRUE"}
+        updated_table.tableType = "EXTERNAL_TABLE"
+        # act
+        hive_metastore_client.create_external_table(table)
+
+        # assert
+        assert table.parameters == updated_table.parameters
+        mocked_create_table.assert_called_once_with(updated_table)


### PR DESCRIPTION
## Why? :open_book:
According to what we discovered in the issue https://github.com/quintoandar/hive-metastore-client/issues/41, there is an error in the Hive metastore server that creates the table as a MANAGED_TABLE instead of EXTERNAL_TABLE when a table is created with default the tableType (None) or equal to EXTERNAL_TABLE.
We decided to enforce the parameter EXTERNAL=TRUE so the table will be created correctly as an external table.

## What? :wrench:
Add new method create_external_table that enforces the parameter EXTERNAL=TRUE and tableType='EXTERNAL_TABLE'

## Type of change :file_cabinet:
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How everything was tested? :straight_ruler:
Unit tests + example file.

## Checklist :memo:
- [x] I have added labels to distinguish the type of pull request.
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] I have made sure that new and existing unit tests pass locally with my changes;
