### PR TITLE
[DAE-94] Add get_table_partition_keys and keys_names methods

### DIFF
--- a/docs/source/getstarted.md
+++ b/docs/source/getstarted.md
@@ -26,6 +26,10 @@ Click on the following links to open the [examples](https://github.com/quintoand
 
 **[#4 Add partitions to a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/add_partitions.py)**
 
+**[#5 Get partition keys from a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/get_partition_keys.py)**
+
+**[#6 Get partition keys names from a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/get_partition_keys_names.py)**
+
 ## Available methods
 
 You can see all the Hive Metastore server available methods by looking at the 
@@ -39,3 +43,5 @@ the [`HiveMetastoreClient`](https://github.com/quintoandar/hive-metastore-client
 - [`drop_columns_from_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.drop_columns_from_table)
 - [`add_partitions_if_not_exists`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.add_partitions_if_not_exists)
 - [`create_database_if_not_exists`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.create_database_if_not_exists)
+- [`get_partition_keys`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.get_partition_keys)
+- [`get_partition_keys_names`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.get_partition_keys_names)

--- a/docs/source/getstarted.md
+++ b/docs/source/getstarted.md
@@ -26,7 +26,7 @@ Click on the following links to open the [examples](https://github.com/quintoand
 
 **[#4 Add partitions to a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/add_partitions.py)**
 
-**[#5 Get partition keys from a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/get_partition_keys.py)**
+**[#5 Get partition keys objects from a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/get_partition_keys_objects.py)**
 
 **[#6 Get partition keys names from a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/get_partition_keys_names.py)**
 
@@ -43,5 +43,5 @@ the [`HiveMetastoreClient`](https://github.com/quintoandar/hive-metastore-client
 - [`drop_columns_from_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.drop_columns_from_table)
 - [`add_partitions_if_not_exists`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.add_partitions_if_not_exists)
 - [`create_database_if_not_exists`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.create_database_if_not_exists)
-- [`get_partition_keys`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.get_partition_keys)
+- [`get_partition_keys_objects`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.get_partition_keys_objects)
 - [`get_partition_keys_names`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.get_partition_keys_names)

--- a/examples/get_partition_keys.py
+++ b/examples/get_partition_keys.py
@@ -1,0 +1,11 @@
+from hive_metastore_client import HiveMetastoreClient
+
+HIVE_HOST = "<ADD_HIVE_HOST_HERE>"
+HIVE_PORT = 9083
+
+DATABASE_NAME = "database_name"
+TABLE_NAME = "table_name"
+
+with HiveMetastoreClient(HIVE_HOST, HIVE_PORT) as hive_client:
+    # Retrieving the partition keys via table schema
+    hive_client.get_partition_keys(DATABASE_NAME, TABLE_NAME)

--- a/examples/get_partition_keys_names.py
+++ b/examples/get_partition_keys_names.py
@@ -1,0 +1,11 @@
+from hive_metastore_client import HiveMetastoreClient
+
+HIVE_HOST = "<ADD_HIVE_HOST_HERE>"
+HIVE_PORT = 9083
+
+DATABASE_NAME = "database_name"
+TABLE_NAME = "table_name"
+
+with HiveMetastoreClient(HIVE_HOST, HIVE_PORT) as hive_client:
+    # Retrieving the partition keys names via table schema
+    hive_client.get_partition_keys_names(DATABASE_NAME, TABLE_NAME)

--- a/examples/get_partition_keys_objects.py
+++ b/examples/get_partition_keys_objects.py
@@ -8,4 +8,4 @@ TABLE_NAME = "table_name"
 
 with HiveMetastoreClient(HIVE_HOST, HIVE_PORT) as hive_client:
     # Retrieving the partition keys via table schema
-    hive_client.get_partition_keys(DATABASE_NAME, TABLE_NAME)
+    hive_client.get_partition_keys_objects(DATABASE_NAME, TABLE_NAME)

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -213,11 +213,13 @@ class HiveMetastoreClient(ThriftClient):
                 "lists does not match"
             )
 
-    def get_partition_keys(self, db_name: str, table_name: str) -> List[FieldSchema]:
+    def get_partition_keys_objects(
+        self, db_name: str, table_name: str
+    ) -> List[FieldSchema]:
         """
-        Gets the partition keys from a table.
+        Gets the partition keys objects, containing the metadata, from a table.
 
-        An empty list will return when no table is found or
+        An empty list will be returned when no table is found or
         when the table has no partitions
 
         :param db_name: database name where the table is at
@@ -230,11 +232,13 @@ class HiveMetastoreClient(ThriftClient):
         """
         Gets the partition keys names from a table.
 
-        An empty list will return when no table is found or
+        An empty list will be returned when no table is found or
         when the table has no partitions
 
         :param db_name: database name where the table is at
         :param table_name: table name which the partition keys belong to
         """
-        partition_keys = self.get_partition_keys(db_name=db_name, table_name=table_name)
+        partition_keys = self.get_partition_keys_objects(
+            db_name=db_name, table_name=table_name
+        )
         return [partition.name for partition in partition_keys]

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -212,3 +212,29 @@ class HiveMetastoreClient(ThriftClient):
                 "m=_validate_lists_length, msg=The length of the two provided "
                 "lists does not match"
             )
+
+    def get_partition_keys(self, db_name: str, table_name: str) -> List[FieldSchema]:
+        """
+        Gets the partition keys from a table.
+
+        An empty list will return when no table is found or
+        when the table has no partitions
+
+        :param db_name: database name where the table is at
+        :param table_name: table name which the partition keys belong to
+        """
+        table = self.get_table(dbname=db_name, tbl_name=table_name)
+        return list(table.partitionKeys) if table else []
+
+    def get_partition_keys_names(self, db_name: str, table_name: str) -> List[str]:
+        """
+        Gets the partition keys names from a table.
+
+        An empty list will return when no table is found or
+        when the table has no partitions
+
+        :param db_name: database name where the table is at
+        :param table_name: table name which the partition keys belong to
+        """
+        partition_keys = self.get_partition_keys(db_name=db_name, table_name=table_name)
+        return [partition.name for partition in partition_keys]

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -297,7 +297,7 @@ class TestHiveMetastoreClient:
         mocked_create_database.assert_called_once_with(mocked_database_obj)
 
     @mock.patch.object(HiveMetastoreClient, "get_table", return_value=None)
-    def test_get_partition_keys_with_invalid_table(
+    def test_get_partition_keys_objects_with_invalid_table(
         self, mocked_get_table, hive_metastore_client,
     ):
         # arrange
@@ -305,7 +305,7 @@ class TestHiveMetastoreClient:
         database_name = "database_name"
 
         # act
-        returned_value = hive_metastore_client.get_partition_keys(
+        returned_value = hive_metastore_client.get_partition_keys_objects(
             database_name, table_name
         )
 
@@ -316,7 +316,7 @@ class TestHiveMetastoreClient:
         )
 
     @mock.patch.object(HiveMetastoreClient, "get_table")
-    def test_get_partition_keys_with_not_partitioned_table(
+    def test_get_partition_keys_objects_with_not_partitioned_table(
         self, mocked_get_table, hive_metastore_client,
     ):
         # arrange
@@ -328,7 +328,7 @@ class TestHiveMetastoreClient:
         mocked_get_table.return_value = mocked_table
 
         # act
-        returned_value = hive_metastore_client.get_partition_keys(
+        returned_value = hive_metastore_client.get_partition_keys_objects(
             database_name, table_name
         )
 
@@ -339,7 +339,7 @@ class TestHiveMetastoreClient:
         )
 
     @mock.patch.object(HiveMetastoreClient, "get_table")
-    def test_get_partition_keys_with_partitioned_table(
+    def test_get_partition_keys_objects_with_partitioned_table(
         self, mocked_get_table, hive_metastore_client,
     ):
         # arrange
@@ -352,7 +352,7 @@ class TestHiveMetastoreClient:
         mocked_get_table.return_value = mocked_table
 
         # act
-        returned_value = hive_metastore_client.get_partition_keys(
+        returned_value = hive_metastore_client.get_partition_keys_objects(
             database_name, table_name
         )
 
@@ -362,9 +362,11 @@ class TestHiveMetastoreClient:
             dbname=database_name, tbl_name=table_name
         )
 
-    @mock.patch.object(HiveMetastoreClient, "get_partition_keys", return_value=[])
+    @mock.patch.object(
+        HiveMetastoreClient, "get_partition_keys_objects", return_value=[]
+    )
     def test_get_partition_keys_names_with_invalid_or_not_partitioned_table(
-        self, mocked_get_partition_keys, hive_metastore_client,
+        self, mocked_get_partition_keys_objects, hive_metastore_client,
     ):
         # arrange
         table_name = "table_name"
@@ -377,13 +379,15 @@ class TestHiveMetastoreClient:
 
         # assert
         assert returned_value == []
-        mocked_get_partition_keys.assert_called_once_with(
+        mocked_get_partition_keys_objects.assert_called_once_with(
             db_name=database_name, table_name=table_name
         )
 
-    @mock.patch.object(HiveMetastoreClient, "get_partition_keys", return_value=[])
+    @mock.patch.object(
+        HiveMetastoreClient, "get_partition_keys_objects", return_value=[]
+    )
     def test_get_partition_keys_with_partitioned_table(
-        self, mocked_get_partition_keys, hive_metastore_client,
+        self, mocked_get_partition_keys_objects, hive_metastore_client,
     ):
         # arrange
         table_name = "table_name"
@@ -392,7 +396,7 @@ class TestHiveMetastoreClient:
         mocked_partition_a.name = "mocked_partition_a"
         mocked_partition_b = Mock()
         mocked_partition_b.name = "mocked_partition_b"
-        mocked_get_partition_keys.return_value = [
+        mocked_get_partition_keys_objects.return_value = [
             mocked_partition_a,
             mocked_partition_b,
         ]
@@ -405,6 +409,6 @@ class TestHiveMetastoreClient:
 
         # assert
         assert returned_value == expected_return
-        mocked_get_partition_keys.assert_called_once_with(
+        mocked_get_partition_keys_objects.assert_called_once_with(
             db_name=database_name, table_name=table_name
         )

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -386,7 +386,7 @@ class TestHiveMetastoreClient:
     @mock.patch.object(
         HiveMetastoreClient, "get_partition_keys_objects", return_value=[]
     )
-    def test_get_partition_keys_with_partitioned_table(
+    def test_get_partition_keys_names_with_partitioned_table(
         self, mocked_get_partition_keys_objects, hive_metastore_client,
     ):
         # arrange

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -295,3 +295,116 @@ class TestHiveMetastoreClient:
 
         # assert
         mocked_create_database.assert_called_once_with(mocked_database_obj)
+
+    @mock.patch.object(HiveMetastoreClient, "get_table", return_value=None)
+    def test_get_partition_keys_with_invalid_table(
+        self, mocked_get_table, hive_metastore_client,
+    ):
+        # arrange
+        table_name = "table_name"
+        database_name = "database_name"
+
+        # act
+        returned_value = hive_metastore_client.get_partition_keys(
+            database_name, table_name
+        )
+
+        # assert
+        assert returned_value == []
+        mocked_get_table.assert_called_once_with(
+            dbname=database_name, tbl_name=table_name
+        )
+
+    @mock.patch.object(HiveMetastoreClient, "get_table")
+    def test_get_partition_keys_with_not_partitioned_table(
+        self, mocked_get_table, hive_metastore_client,
+    ):
+        # arrange
+        table_name = "table_name"
+        database_name = "database_name"
+        mocked_table = Mock()
+        # the default return from hive metastore for not partitioned tables is an empty list
+        mocked_table.partitionKeys = []
+        mocked_get_table.return_value = mocked_table
+
+        # act
+        returned_value = hive_metastore_client.get_partition_keys(
+            database_name, table_name
+        )
+
+        # assert
+        assert returned_value == []
+        mocked_get_table.assert_called_once_with(
+            dbname=database_name, tbl_name=table_name
+        )
+
+    @mock.patch.object(HiveMetastoreClient, "get_table")
+    def test_get_partition_keys_with_partitioned_table(
+        self, mocked_get_table, hive_metastore_client,
+    ):
+        # arrange
+        table_name = "table_name"
+        database_name = "database_name"
+        mocked_table = Mock()
+        mocked_partition_a = Mock()
+        mocked_partition_b = Mock()
+        mocked_table.partitionKeys = [mocked_partition_a, mocked_partition_b]
+        mocked_get_table.return_value = mocked_table
+
+        # act
+        returned_value = hive_metastore_client.get_partition_keys(
+            database_name, table_name
+        )
+
+        # assert
+        assert returned_value == [mocked_partition_a, mocked_partition_b]
+        mocked_get_table.assert_called_once_with(
+            dbname=database_name, tbl_name=table_name
+        )
+
+    @mock.patch.object(HiveMetastoreClient, "get_partition_keys", return_value=[])
+    def test_get_partition_keys_names_with_invalid_or_not_partitioned_table(
+        self, mocked_get_partition_keys, hive_metastore_client,
+    ):
+        # arrange
+        table_name = "table_name"
+        database_name = "database_name"
+
+        # act
+        returned_value = hive_metastore_client.get_partition_keys_names(
+            database_name, table_name
+        )
+
+        # assert
+        assert returned_value == []
+        mocked_get_partition_keys.assert_called_once_with(
+            db_name=database_name, table_name=table_name
+        )
+
+    @mock.patch.object(HiveMetastoreClient, "get_partition_keys", return_value=[])
+    def test_get_partition_keys_with_partitioned_table(
+        self, mocked_get_partition_keys, hive_metastore_client,
+    ):
+        # arrange
+        table_name = "table_name"
+        database_name = "database_name"
+        mocked_partition_a = Mock()
+        mocked_partition_a.name = "mocked_partition_a"
+        mocked_partition_b = Mock()
+        mocked_partition_b.name = "mocked_partition_b"
+        mocked_get_partition_keys.return_value = [
+            mocked_partition_a,
+            mocked_partition_b,
+        ]
+        expected_return = ["mocked_partition_a", "mocked_partition_b"]
+
+        # act
+        returned_value = hive_metastore_client.get_partition_keys_names(
+            database_name, table_name
+        )
+
+        # assert
+        assert returned_value == expected_return
+        mocked_get_partition_keys.assert_called_once_with(
+            db_name=database_name, table_name=table_name
+        )

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -1,3 +1,4 @@
+from copy import copy
 from unittest import mock
 from unittest.mock import Mock, ANY
 


### PR DESCRIPTION
## Why? :open_book:
There is no 'SHOW PARTITION' equivalent method in Thrift mapping, therefore we needed to create one to avoid fetching the table/table-schema every single time.
Since both returns (partitions definitions and partition names) could be helpful, we already created both.

## What? :wrench:
- Adding `get_table_partition_keys` and `get_table_partition_keys_names` methods.
- Adding respective examples
- Adding respective unit tests
- Adding new methods to doc

## Type of change :file_cabinet:
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How everything was tested? :straight_ruler:
Via unit tests and manual testing;

## Checklist :memo:
- [X] I have added labels to distinguish the type of pull request.
- [X] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [X] I have performed a self-review of my own code;
- [X] I have made corresponding changes to the documentation;
- [X] I have added tests that prove my fix is effective or that my feature works;
- [X] I have made sure that new and existing unit tests pass locally with my changes;