### PR TITLE
[DAE-94] Release 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Preferably use **Added**, **Changed**, **Removed** and **Fixed** topics in each 
 ### Added
 * Added create_external_table method ([#42](https://github.com/quintoandar/hive-metastore-client/pull/42))
 * Added get_partition_keys_objects and get_partition_keys_names methods ([#43](https://github.com/quintoandar/hive-metastore-client/pull/43))
-
+### Fixed
+* Enforcing type as EXTERNAL when creating external tables ([#41](https://github.com/quintoandar/hive-metastore-client/issues/41))
 
 ## [1.0.3](https://github.com/quintoandar/hive-metastore-client/releases/tag/1.0.3)
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 Preferably use **Added**, **Changed**, **Removed** and **Fixed** topics in each release or unreleased log for a better organization.
 
+## [1.0.4](https://github.com/quintoandar/hive-metastore-client/releases/tag/1.0.4)
+### Added
+* Added create_external_table method ([#42](https://github.com/quintoandar/hive-metastore-client/pull/42))
+* Added get_partition_keys_objects and get_partition_keys_names methods ([#43](https://github.com/quintoandar/hive-metastore-client/pull/43))
+
+
 ## [1.0.3](https://github.com/quintoandar/hive-metastore-client/releases/tag/1.0.3)
 ### Changed
 * Handled exception when adding duplicate partitions ([#37](https://github.com/quintoandar/hive-metastore-client/pull/37))

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 __package_name__ = "hive_metastore_client"
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 __repository_url__ = "https://github.com/quintoandar/hive-metastore-client"
 
 with open("requirements.txt") as f:


### PR DESCRIPTION
## Why? :open_book:
Releasing version 1.0.4

## What? :wrench:
- Added create_external_table method - #43 
- Added get_partition_keys_objects and get_partition_keys_names methods - #42 

## Type of change :file_cabinet:
- [x] Release

## Checklist :memo:
- [X] I have added labels to distinguish the type of pull request.
- [X] I have performed a self-review of my own code;
- [X] I have made corresponding changes to the documentation;
- [X] I have made sure that new and existing unit tests pass locally with my changes;