### PR TITLE
[DAE-113] Changing max_parts from get_partitions method to int32

### DIFF
--- a/thrift_files/libraries/thrift_hive_metastore_client/ThriftHiveMetastore.py
+++ b/thrift_files/libraries/thrift_hive_metastore_client/ThriftHiveMetastore.py
@@ -30473,8 +30473,8 @@ class get_partitions_args(object):
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
-                if ftype == TType.I16:
-                    self.max_parts = iprot.readI16()
+                if ftype == TType.I32:
+                    self.max_parts = iprot.readI32()
                 else:
                     iprot.skip(ftype)
             else:
@@ -30506,8 +30506,8 @@ class get_partitions_args(object):
             )
             oprot.writeFieldEnd()
         if self.max_parts is not None:
-            oprot.writeFieldBegin("max_parts", TType.I16, 3)
-            oprot.writeI16(self.max_parts)
+            oprot.writeFieldBegin("max_parts", TType.I32, 3)
+            oprot.writeI32(self.max_parts)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -30531,7 +30531,7 @@ get_partitions_args.thrift_spec = (
     None,  # 0
     (1, TType.STRING, "db_name", "UTF8", None,),  # 1
     (2, TType.STRING, "tbl_name", "UTF8", None,),  # 2
-    (3, TType.I16, "max_parts", None, -1,),  # 3
+    (3, TType.I32, "max_parts", None, -1,),  # 3
 )
 
 

--- a/thrift_files/readme.md
+++ b/thrift_files/readme.md
@@ -30,5 +30,5 @@ thrift --gen py fb303.thrift
 
 Some auto-generated code from Thrift communication with Hive Metastore can be changed to provide more features, thus allowing a more customized integration.
 
-The following PRs change the Thrift base files and **need to be re-written** in case of re-generation by the previous steps:
-- So far no PR manually changing base files were deployed. 
+The following PRs change the Thrift base files and/or source files. Check whether they **need to be re-written** in case of re-generation by the previous steps:
+- [#45](https://github.com/quintoandar/hive-metastore-client/pull/45) - Changing type, from I16 to I32, of `max_parts` parameter of `get_partitions` method.

--- a/thrift_files/readme.md
+++ b/thrift_files/readme.md
@@ -31,4 +31,4 @@ thrift --gen py fb303.thrift
 Some auto-generated code from Thrift communication with Hive Metastore can be changed to provide more features, thus allowing a more customized integration.
 
 The following PRs change the Thrift base files and/or source files. Check whether they **need to be re-written** in case of re-generation by the previous steps:
-- [#45](https://github.com/quintoandar/hive-metastore-client/pull/45) - Changing type, from I16 to I32, of `max_parts` parameter of `get_partitions` method.
+- [#45](https://github.com/quintoandar/hive-metastore-client/pull/45) - Changing type, from I16 to I32, of `max_parts` parameter from `get_partitions` method.

--- a/thrift_files/source/hive_metastore.thrift
+++ b/thrift_files/source/hive_metastore.thrift
@@ -1803,7 +1803,7 @@ service ThriftHiveMetastore extends fb303.FacebookService
 
   // returns all the partitions for this table in reverse chronological order.
   // If max parts is given then it will return only that many.
-  list<Partition> get_partitions(1:string db_name, 2:string tbl_name, 3:i16 max_parts=-1)
+  list<Partition> get_partitions(1:string db_name, 2:string tbl_name, 3:i32 max_parts=-1)
                        throws(1:NoSuchObjectException o1, 2:MetaException o2)
   list<Partition> get_partitions_with_auth(1:string db_name, 2:string tbl_name, 3:i16 max_parts=-1,
      4: string user_name, 5: list<string> group_names) throws(1:NoSuchObjectException o1, 2:MetaException o2)


### PR DESCRIPTION
## Why? :open_book:
The `max_parts` parameter from `get_partitions` method was limiting our querying to 32k partitions.

## What? :wrench:
Adjusting `max_parts` parameter from `get_partitions` method to handle 64k values.

## Type of change :file_cabinet:
- [X] Adjustment (non-breaking change)

## How everything was tested? :straight_ruler:
Executed method get_partitions with the parameter as the new type and it allowed 60k as `max_parts` and returned the expected result.

## Checklist :memo:
- [X] I have added labels to distinguish the type of pull request.
- [X] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [X] I have performed a self-review of my own code;
- [X] I have made sure that new and existing unit tests pass locally with my changes;