### PR TITLE
[DAE-113] Adding base warning about changing thrift base files

### DIFF
--- a/thrift_files/readme.md
+++ b/thrift_files/readme.md
@@ -30,5 +30,5 @@ thrift --gen py fb303.thrift
 
 Some auto-generated code from Thrift communication with Hive Metastore can be changed to provide more features, thus allowing a more customized integration.
 
-The following PR's change the Thrift base files and **need to be re-written** in case of re-generation by the previous steps:
+The following PRs change the Thrift base files and **need to be re-written** in case of re-generation by the previous steps:
 - So far no PR manually changing base files were deployed. 

--- a/thrift_files/readme.md
+++ b/thrift_files/readme.md
@@ -25,3 +25,10 @@ thrift --gen py fb303.thrift
 3 - Now you have the new python code generated inside `gen-py`. Extract the classes and place them in the right directories.
 
 4 - The generated files are huge, therefore be sure that the generated files directory names are ignored in the make commands _style-check_ and _apply-lint_. So these files are not evaluated during the checks.
+
+## Manual adjustments to Thrift source files
+
+Some auto-generated code from Thrift communication with Hive Metastore can be changed to provide more features, thus allowing a more customized integration.
+
+The following PR's change the Thrift base files and **need to be re-written** in case of re-generation by the previous steps:
+- So far no PR manually changing base files were deployed. 


### PR DESCRIPTION
## Why? :open_book:
The following PR[ #45 ] is changing Thrift source (auto-generated) code. 
We need to keep in mind that any re-build of thrift source code will erase the change, therefore we are adding a list of PRs that need to be re-written/re-deployed in re-build case.

## What? :wrench:
- Adding base message with no linked PR.

## Type of change :file_cabinet:
- [X] Documentation

## Checklist :memo:
- [X] I have added labels to distinguish the type of pull request.
- [X] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [X] I have performed a self-review of my own code;
- [X] I have made corresponding changes to the documentation;