### PR TITLE
[DAE-116] Add method bulk drop

### DIFF
--- a/docs/source/getstarted.md
+++ b/docs/source/getstarted.md
@@ -32,6 +32,8 @@ Click on the following links to open the [examples](https://github.com/quintoand
 
 **[#7 Get partition keys names from a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/get_partition_keys_names.py)**
 
+**[#8 Bulk drop partitions values from a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/bulk_drop_partitions.py)**
+
 ## Available methods
 
 You can see all the Hive Metastore server available methods by looking at the 
@@ -48,3 +50,4 @@ the [`HiveMetastoreClient`](https://github.com/quintoandar/hive-metastore-client
 - [`create_external_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.create_external_table)
 - [`get_partition_keys_objects`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.get_partition_keys_objects)
 - [`get_partition_keys_names`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.get_partition_keys_names)
+- [`bulk_drop_partitions`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.bulk_drop_partitions)

--- a/examples/bulk_drop_partitions.py
+++ b/examples/bulk_drop_partitions.py
@@ -1,0 +1,20 @@
+from hive_metastore_client import HiveMetastoreClient
+
+HIVE_HOST = "<ADD_HIVE_HOST_HERE>"
+HIVE_PORT = 9083
+
+DATABASE_NAME = "database_name"
+TABLE_NAME = "table_name"
+
+partition_list = [
+    ["2020", "1", "28"],
+    ["2020", "1", "29"],
+    ["2020", "1", "30"],
+    ["2020", "1", "31"],
+]
+
+with HiveMetastoreClient(HIVE_HOST, HIVE_PORT) as hive_client:
+    # Dropping various partitions at once
+    hive_client.bulk_drop_partitions(
+        DATABASE_NAME, TABLE_NAME, partition_list, delete_data=False
+    )

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -259,3 +259,26 @@ class HiveMetastoreClient(ThriftClient):
             db_name=db_name, table_name=table_name
         )
         return [partition.name for partition in partition_keys]
+
+    def bulk_drop_partitions(
+        self,
+        db_name: str,
+        table_name: str,
+        partition_list: List[List[str]],
+        delete_data: bool = False,
+    ) -> None:
+        """
+        Drops the partitions values from the partition list.
+
+        This methods simulates a bulk drop for the user, since the server only
+         supports an unitary drop
+
+        :param db_name: database name of the table
+        :param table_name: table name
+        :param partition_list: the partitions to be dropped
+        :param delete_data: indicates whether the data respective to the
+         partition should be dropped in the source.
+        :return:
+        """
+        for partition_values in partition_list:
+            self.drop_partition(db_name, table_name, partition_values, delete_data)

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -273,23 +273,26 @@ class HiveMetastoreClient(ThriftClient):
 
         This methods simulates a bulk drop for the user, since the server only
          supports an unitary drop.
+        If some partition cannot be dropped an exception will be thrown in the
+         end of execution.
 
         :param db_name: database name of the table
         :param table_name: table name
         :param partition_list: the partitions to be dropped
         :param delete_data: indicates whether the data respective to the
          partition should be dropped in the source.
-        :return:
+        :raises: NoSuchObjectException
         """
         partitions_not_dropped = []
         for partition_values in partition_list:
             try:
                 self.drop_partition(db_name, table_name, partition_values, delete_data)
-            except:
+            except NoSuchObjectException:
                 partitions_not_dropped.append(partition_values)
 
         if partitions_not_dropped:
-            raise Exception(
-                f"m=bulk_drop_partitions, partitions_not_dropped={partitions_not_dropped}, "
-                "msg=Some partition values were not dropped."
+            raise NoSuchObjectException(
+                "m=bulk_drop_partitions, partitions_not_dropped="
+                f"{partitions_not_dropped}, msg=Some partition values were not "
+                "dropped because they do not exist."
             )

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -271,7 +271,7 @@ class HiveMetastoreClient(ThriftClient):
         Drops the partitions values from the partition list.
 
         This methods simulates a bulk drop for the user, since the server only
-         supports an unitary drop
+         supports an unitary drop.
 
         :param db_name: database name of the table
         :param table_name: table name

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -15,6 +15,7 @@ from thrift_files.libraries.thrift_hive_metastore_client.ttypes import (  # type
     Database,
     AlreadyExistsException,
     Table,
+    NoSuchObjectException,
 )
 
 
@@ -280,5 +281,15 @@ class HiveMetastoreClient(ThriftClient):
          partition should be dropped in the source.
         :return:
         """
+        partitions_not_dropped = []
         for partition_values in partition_list:
-            self.drop_partition(db_name, table_name, partition_values, delete_data)
+            try:
+                self.drop_partition(db_name, table_name, partition_values, delete_data)
+            except:
+                partitions_not_dropped.append(partition_values)
+
+        if partitions_not_dropped:
+            raise Exception(
+                f"m=bulk_drop_partitions, partitions_not_dropped={partitions_not_dropped}, "
+                "msg=Some partition values were not dropped."
+            )

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -7,9 +7,6 @@ from pytest import raises
 
 from hive_metastore_client import HiveMetastoreClient
 from hive_metastore_client.builders import TableBuilder
-from thrift_files.libraries.thrift_hive_metastore_client.ThriftHiveMetastore import (
-    Client as ThriftClient,
-)
 from thrift_files.libraries.thrift_hive_metastore_client.ttypes import (
     FieldSchema,
     NoSuchObjectException,
@@ -465,14 +462,13 @@ class TestHiveMetastoreClient:
         ]
 
         # assert
-        with raises(NoSuchObjectException) as e:
+        with raises(
+            NoSuchObjectException,
+            match=r"partitions_not_dropped=\[\['2021', '1', '1'\], \['2021', '1', '2'\]\]",
+        ):
             # act
             hive_metastore_client.bulk_drop_partitions(
                 db_name, table_name, partition_list, mock.ANY
             )
 
         assert mock_drop_partition.call_count == len(partition_list)
-        assert e.value == NoSuchObjectException(
-            "m=bulk_drop_partitions, partitions_not_dropped=[['2021', '1', '1'], ['2021', '1', '2']],"
-            " msg=Some partition values were not dropped because they do not exist."
-        )

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -434,3 +434,19 @@ class TestHiveMetastoreClient:
         mocked_get_partition_keys_objects.assert_called_once_with(
             db_name=database_name, table_name=table_name
         )
+
+    @mock.patch.object(HiveMetastoreClient, "drop_partition", return_value=None)
+    def test_bulk_drop_partitions(self, mock_drop_partition, hive_metastore_client):
+        # arrange
+        db_name = "db_name"
+        table_name = "table_name"
+        partition_list = [["1995", "9", "22"], ["2013", "2", "14"], ["2021", "1", "1"]]
+        table_data = mock.ANY
+
+        # act
+        hive_metastore_client.bulk_drop_partitions(
+            db_name, table_name, partition_list, table_data
+        )
+
+        # assert
+        assert mock_drop_partition.call_count == len(partition_list)

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -441,11 +441,10 @@ class TestHiveMetastoreClient:
         db_name = "db_name"
         table_name = "table_name"
         partition_list = [["1995", "9", "22"], ["2013", "2", "14"], ["2021", "1", "1"]]
-        table_data = mock.ANY
 
         # act
         hive_metastore_client.bulk_drop_partitions(
-            db_name, table_name, partition_list, table_data
+            db_name, table_name, partition_list, mock.ANY
         )
 
         # assert


### PR DESCRIPTION
## Why? :open_book:
We don't have a method to drop all partitions at once. 
So to keep the interface cleaner for the lib's users we decided to add a method that encapsulates the behavior of dropping each partition from a list.

## What? :wrench:
Add method `bulk_drop_partitions`

## Type of change :file_cabinet:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Release

## How everything was tested? :straight_ruler:
Unit tests

## Checklist :memo:
- [x] I have added labels to distinguish the type of pull request.
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] I have made sure that new and existing unit tests pass locally with my changes;
