### PR TITLE
[DAE-121]  Adding custom get_partition_values method

### DIFF
--- a/docs/source/getstarted.md
+++ b/docs/source/getstarted.md
@@ -32,6 +32,9 @@ Click on the following links to open the [examples](https://github.com/quintoand
 
 **[#7 Get partition keys names from a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/get_partition_keys_names.py)**
 
+**[#8 Get partition values from a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/get_partition_values_from_table.py)**
+
+
 ## Available methods
 
 You can see all the Hive Metastore server available methods by looking at the 
@@ -48,3 +51,4 @@ the [`HiveMetastoreClient`](https://github.com/quintoandar/hive-metastore-client
 - [`create_external_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.create_external_table)
 - [`get_partition_keys_objects`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.get_partition_keys_objects)
 - [`get_partition_keys_names`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.get_partition_keys_names)
+- [`get_partition_values_from_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.get_partition_values_from_table)

--- a/examples/get_partition_values_from_table.py
+++ b/examples/get_partition_values_from_table.py
@@ -1,0 +1,13 @@
+from hive_metastore_client import HiveMetastoreClient
+
+HIVE_HOST = "<ADD_HIVE_HOST_HERE>"
+HIVE_PORT = 9083
+
+DATABASE_NAME = "database_name"
+TABLE_NAME = "table_name"
+
+with HiveMetastoreClient(HIVE_HOST, HIVE_PORT) as hive_client:
+    # Getting partition values as a list from specified table
+    return_value = hive_client.get_partition_values_from_table(
+        DATABASE_NAME, TABLE_NAME
+    )

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -273,7 +273,7 @@ class HiveMetastoreClient(ThriftClient):
         when the table has no partitions
 
         :param db_name: database name where the table is at
-        :param table_name: table name which the partition keys belong to
+        :param table_name: table name which the partitions belong to
         """
         partition_values_response = self.get_partition_values(
             PartitionValuesRequest(

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -15,6 +15,7 @@ from thrift_files.libraries.thrift_hive_metastore_client.ttypes import (  # type
     Database,
     AlreadyExistsException,
     Table,
+    PartitionValuesRequest,
 )
 
 
@@ -259,3 +260,31 @@ class HiveMetastoreClient(ThriftClient):
             db_name=db_name, table_name=table_name
         )
         return [partition.name for partition in partition_keys]
+
+    def get_partition_values_from_table(
+        self, db_name: str, table_name: str
+    ) -> List[List[str]]:
+        """
+        Gets the partition names from a table.
+
+        It dynamically fetches the table's partition keys.
+
+        An empty list will be returned when no table is found or
+        when the table has no partitions
+
+        :param db_name: database name where the table is at
+        :param table_name: table name which the partition keys belong to
+        """
+        partition_values_response = self.get_partition_values(
+            PartitionValuesRequest(
+                dbName=db_name,
+                tblName=table_name,
+                partitionKeys=self.get_partition_keys_objects(
+                    db_name=db_name, table_name=table_name
+                ),
+            )
+        )
+
+        return [
+            partition.row for partition in partition_values_response.partitionValues
+        ]

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -304,10 +304,10 @@ class HiveMetastoreClient(ThriftClient):
         """
         Gets the partition names from a table.
 
-        It dynamically fetches the table's partition keys.
+        It automatically fetches the table's partition keys.
 
         An empty list will be returned when no table is found or
-        when the table has no partitions
+        when the table has no partitions.
 
         :param db_name: database name where the table is at
         :param table_name: table name which the partitions belong to

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -493,6 +493,7 @@ class TestHiveMetastoreClient:
         mocked_partition_values_partition_a = Mock()
         mocked_partition_values_partition_a.row = ["partition_a"]
         mocked_partition_values.append(mocked_partition_values_partition_a)
+
         mocked_partition_values_partition_b = Mock()
         mocked_partition_values_partition_b.row = ["partition_b"]
         mocked_partition_values.append(mocked_partition_values_partition_b)


### PR DESCRIPTION
## Why? :open_book:
Thrift's native `get_partition_values` expect some parameters that we can auto-generate, and also its return contains too much info. We wanted a clear and straight-forward method to get the partition-values from a given table.

The method name looks a bit redundant, being called `get_partition_values_from_table`. However we wanted to leave the base method available... therefore the most clean method name we could think of was this one.

## What? :wrench:
- Adding method `get_partition_values_from_table` method
- Adding example, documentation and unit test to respective method.

## Type of change :file_cabinet:
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update
- 

## How everything was tested? :straight_ruler:
Via single and unit test.

## Checklist :memo:
- [X] I have added labels to distinguish the type of pull request.
- [X] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [X] I have performed a self-review of my own code;
- [X] I have made corresponding changes to the documentation;
- [X] I have added tests that prove my fix is effective or that my feature works;
- [X] I have made sure that new and existing unit tests pass locally with my changes;