### PR TITLE
[DAE-117] Add method to get partitions with name and type

### DIFF
--- a/docs/source/getstarted.md
+++ b/docs/source/getstarted.md
@@ -30,11 +30,13 @@ Click on the following links to open the [examples](https://github.com/quintoand
 
 **[#6 Get partition keys objects from a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/get_partition_keys_objects.py)**
 
-**[#7 Get partition keys names from a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/get_partition_keys_names.py)**
+**[#7 Get partition keys (names & types) from a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/get_partition_keys.py)**
 
-**[#8 Bulk drop partitions values from a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/bulk_drop_partitions.py)**
+**[#8 Get partition keys (names only) from a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/get_partition_keys_names.py)**
 
-**[#9 Get partition values from a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/get_partition_values_from_table.py)**
+**[#9 Bulk drop partitions values from a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/bulk_drop_partitions.py)**
+
+**[#10 Get partition values from a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/get_partition_values_from_table.py)**
 
 ## Available methods
 
@@ -51,6 +53,7 @@ the [`HiveMetastoreClient`](https://github.com/quintoandar/hive-metastore-client
 - [`create_database_if_not_exists`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.create_database_if_not_exists)
 - [`create_external_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.create_external_table)
 - [`get_partition_keys_objects`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.get_partition_keys_objects)
+- [`get_partition_keys`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.get_partition_keys)
 - [`get_partition_keys_names`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.get_partition_keys_names)
 - [`bulk_drop_partitions`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.bulk_drop_partitions)
 - [`get_partition_values_from_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.get_partition_values_from_table)

--- a/examples/get_partition_keys.py
+++ b/examples/get_partition_keys.py
@@ -7,5 +7,5 @@ DATABASE_NAME = "database_name"
 TABLE_NAME = "table_name"
 
 with HiveMetastoreClient(HIVE_HOST, HIVE_PORT) as hive_client:
-    # Retrieving the partition keys via table schema
-    returned_value = hive_client.get_partition_keys_objects(DATABASE_NAME, TABLE_NAME)
+    # Retrieving the partition keys and types via table schema
+    returned_value = hive_client.get_partition_keys(DATABASE_NAME, TABLE_NAME)

--- a/examples/get_partition_keys_names.py
+++ b/examples/get_partition_keys_names.py
@@ -8,4 +8,4 @@ TABLE_NAME = "table_name"
 
 with HiveMetastoreClient(HIVE_HOST, HIVE_PORT) as hive_client:
     # Retrieving the partition keys names via table schema
-    hive_client.get_partition_keys_names(DATABASE_NAME, TABLE_NAME)
+    returned_value = hive_client.get_partition_keys_names(DATABASE_NAME, TABLE_NAME)

--- a/examples/get_partition_values_from_table.py
+++ b/examples/get_partition_values_from_table.py
@@ -8,6 +8,6 @@ TABLE_NAME = "table_name"
 
 with HiveMetastoreClient(HIVE_HOST, HIVE_PORT) as hive_client:
     # Getting partition values as a list from specified table
-    return_value = hive_client.get_partition_values_from_table(
+    returned_value = hive_client.get_partition_values_from_table(
         DATABASE_NAME, TABLE_NAME
     )

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -269,7 +269,7 @@ class HiveMetastoreClient(ThriftClient):
         Gets the partition keys from a table as a tuple: (name, type).
 
         An empty list will be returned when no table is found or
-        when the table has no partitions
+        when the table has no partitions.
 
         :param db_name: database name where the table is at
         :param table_name: table name which the partition keys belong to

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -1,6 +1,6 @@
 """Hive Metastore Client main class."""
 import copy
-from typing import List, Any
+from typing import List, Any, Tuple
 
 from thrift.protocol import TBinaryProtocol
 from thrift.transport import TSocket, TTransport
@@ -261,6 +261,23 @@ class HiveMetastoreClient(ThriftClient):
             db_name=db_name, table_name=table_name
         )
         return [partition.name for partition in partition_keys]
+
+    def get_partition_keys(
+        self, db_name: str, table_name: str
+    ) -> List[Tuple[str, str]]:
+        """
+        Gets the partition keys from a table as a tuple: (name, type).
+
+        An empty list will be returned when no table is found or
+        when the table has no partitions
+
+        :param db_name: database name where the table is at
+        :param table_name: table name which the partition keys belong to
+        """
+        partition_keys = self.get_partition_keys_objects(
+            db_name=db_name, table_name=table_name
+        )
+        return [(partition.name, partition.type) for partition in partition_keys]
 
     def bulk_drop_partitions(
         self,

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -518,3 +518,53 @@ class TestHiveMetastoreClient:
         mocked_get_partition_values.assert_called_once_with(
             expected_partition_values_request
         )
+
+    @mock.patch.object(
+        HiveMetastoreClient, "get_partition_keys_objects", return_value=[]
+    )
+    def test_get_partition_keys_with_partitioned_table(
+        self, mocked_get_partition_keys_objects, hive_metastore_client
+    ):
+        # arrange
+        db_name = "<db_name>"
+        table_name = "<table_name>"
+
+        partition_1 = Mock()
+        partition_1.name = "name_1"
+        partition_1.type = "type_1"
+
+        partition_2 = Mock()
+        partition_2.name = "name_2"
+        partition_2.type = "type_2"
+
+        mocked_get_partition_keys_objects.return_value = [partition_1, partition_2]
+        expected_value = [("name_1", "type_1"), ("name_2", "type_2")]
+        # act
+        returned_value = hive_metastore_client.get_partition_keys(db_name, table_name)
+
+        # assert
+        assert returned_value == expected_value
+        mocked_get_partition_keys_objects.assert_called_once_with(
+            db_name=db_name, table_name=table_name
+        )
+
+    @mock.patch.object(
+        HiveMetastoreClient, "get_partition_keys_objects", return_value=[]
+    )
+    def test_get_partition_keys_with_non_partitioned_table(
+        self, mocked_get_partition_keys_objects, hive_metastore_client
+    ):
+        # arrange
+        db_name = "<db_name>"
+        table_name = "<table_name>"
+
+        mocked_get_partition_keys_objects.return_value = []
+        expected_value = []
+        # act
+        returned_value = hive_metastore_client.get_partition_keys(db_name, table_name)
+
+        # assert
+        assert returned_value == expected_value
+        mocked_get_partition_keys_objects.assert_called_once_with(
+            db_name=db_name, table_name=table_name
+        )


### PR DESCRIPTION
## Why? :open_book:
We need a method that returns the partitions names & types.

## What? :wrench:
Adding method `get_partition_keys` that gets the partition keys from a table as a tuple: (name, type).

## Type of change :file_cabinet:
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How everything was tested? :straight_ruler:
Unit tests + testing with Hive metastore server.

## Checklist :memo:
- [x] I have added labels to distinguish the type of pull request.
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] I have made sure that new and existing unit tests pass locally with my changes;
