### PR TITLE
[DAE-126] Handle exception when table has no partitions

### DIFF
--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -329,16 +329,19 @@ class HiveMetastoreClient(ThriftClient):
         :param db_name: database name where the table is at
         :param table_name: table name which the partitions belong to
         """
-        partition_values_response = self.get_partition_values(
-            PartitionValuesRequest(
-                dbName=db_name,
-                tblName=table_name,
-                partitionKeys=self.get_partition_keys_objects(
-                    db_name=db_name, table_name=table_name
-                ),
+        try:
+            partition_values_response = self.get_partition_values(
+                PartitionValuesRequest(
+                    dbName=db_name,
+                    tblName=table_name,
+                    partitionKeys=self.get_partition_keys_objects(
+                        db_name=db_name, table_name=table_name
+                    ),
+                )
             )
-        )
-
-        return [
-            partition.row for partition in partition_values_response.partitionValues
-        ]
+            partitions = [
+                partition.row for partition in partition_values_response.partitionValues
+            ]
+        except Exception:
+            partitions = []
+        return partitions


### PR DESCRIPTION
## Why? :open_book:
When using the method `get_partition_values_from_table` with non-partitioned tables we get an exception:
```python
thrift.transport.TTransport.TTransportException: TSocket read 0 bytes
```
We decided to handle this as an empty return, once the table does not have partitions.

## What? :wrench:
modify method `get_partition_values_from_table` handle to handle the Exception

## Type of change :file_cabinet:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## How everything was tested? :straight_ruler:
Unit + testing with Hive Metastore Server

## Checklist :memo:
- [ ] I have added labels to distinguish the type of pull request.
- [ ] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [ ] I have performed a self-review of my own code;
- [ ] I have made corresponding changes to the documentation;
- [ ] I have added tests that prove my fix is effective or that my feature works;
- [ ] I have made sure that new and existing unit tests pass locally with my changes;

## Attention Points :warning:
_Replace me for what the reviewer will need to pay attention to in the PR or just to cover any concerns after the merge._
