### PR TITLE
[DAE-133] Removing types-comparison when dropping a column

### DIFF
--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -117,7 +117,8 @@ class HiveMetastoreClient(ThriftClient):
                     cols.append(col)
             table.sd.cols = cols
 
-            # Hive Metastore enforces that the schema prior and after an ALTER TABLE should be the same,
+            # Hive Metastore enforces that the schema prior and after
+            # an ALTER TABLE should be the same,
             # however when dropping a column the schema will definitely change
             self.setMetaConf(self.COL_TYPE_INCOMPATIBILITY_DISALLOW_CONFIG, "false")
 

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -106,8 +106,13 @@ class TestHiveMetastoreClient:
 
     @mock.patch.object(HiveMetastoreClient, "get_table")
     @mock.patch.object(HiveMetastoreClient, "alter_table")
+    @mock.patch.object(HiveMetastoreClient, "setMetaConf")
     def test_drop_columns_from_table(
-        self, mocked_alter_table, mocked_get_table, hive_metastore_client
+        self,
+        mocked_set_meta_conf,
+        mocked_alter_table,
+        mocked_get_table,
+        hive_metastore_client,
     ):
         # arrange
         db_name = "db_name"
@@ -131,6 +136,9 @@ class TestHiveMetastoreClient:
         )
 
         # assert
+        mocked_set_meta_conf.assert_called_once_with(
+            hive_metastore_client.COL_TYPE_INCOMPATIBILITY_DISALLOW_CONFIG, "false"
+        )
         mocked_get_table.assert_called_once_with(dbname=db_name, tbl_name=table_name)
         mocked_alter_table.assert_called_once_with(
             dbname=db_name, tbl_name=table_name, new_tbl=expected_mocked_table


### PR DESCRIPTION
## Why? :open_book:
When running an ALTER TABLE Hive stores the types of columns from table schema in sequential order to enforce the same types after the ALTER TABLE. However when performing our abstraction of DROP COLUMN, the types may change, since the schema will definitely change.

Currently, if we try to drop a column that changes this 'types order', the following error returns:

> thrift_files.libraries.thrift_hive_metastore_client.ttypes.InvalidOperationException: InvalidOperationException(message='The following columns have types incompatible with the existing columns in their respective positions :\ncolumn_name')


## What? :wrench:
- Adding a call to change metastore settings while in `drop_columns_from_table`:
Allowing, in the current execution, the changing of types when comparing the table schema prior and after ALTER TABLE.
- Adjusting tests

## Type of change :file_cabinet:
- [X] Bug fix (non-breaking change which fixes an issue)

## How everything was tested? :straight_ruler:
Ran the config command both alone and together with the `drop_columns_from_table` and it only succeed in the same 'transaction'.

## Checklist :memo:
- [X] I have added labels to distinguish the type of pull request.
- [X] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [X] I have performed a self-review of my own code;
- [X] I have made corresponding changes to the documentation;
- [X] I have added tests that prove my fix is effective or that my feature works;
- [X] I have made sure that new and existing unit tests pass locally with my changes;

## Attention Points :warning:
_Replace me for what the reviewer will need to pay attention to in the PR or just to cover any concerns after the merge._
