### PR TITLE
[DAE-145] Release 1.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 Preferably use **Added**, **Changed**, **Removed** and **Fixed** topics in each release or unreleased log for a better organization.
 
+## [1.0.8](https://github.com/quintoandar/hive-metastore-client/releases/tag/1.0.8)
+### Changed
+* Added if clause to check the default values for TableBuilder and SerdeInfoBuilder constructor
+  ([#62](https://github.com/quintoandar/hive-metastore-client/pull/62))
+
 ## [1.0.7](https://github.com/quintoandar/hive-metastore-client/releases/tag/1.0.7)
 ### Added
 * Added method `add_partitions_to_table` to add partitions receiving an exception if some partition already exists 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Preferably use **Added**, **Changed**, **Removed** and **Fixed** topics in each 
 
 ## [1.0.8](https://github.com/quintoandar/hive-metastore-client/releases/tag/1.0.8)
 ### Changed
-* Added if clause to check the default values for TableBuilder and SerdeInfoBuilder constructor
+* Added if clause to check the default values for `TableBuilder` and `SerdeInfoBuilder` constructor
   ([#62](https://github.com/quintoandar/hive-metastore-client/pull/62))
 
 ## [1.0.7](https://github.com/quintoandar/hive-metastore-client/releases/tag/1.0.7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Preferably use **Added**, **Changed**, **Removed** and **Fixed** topics in each 
 
 ## [1.0.8](https://github.com/quintoandar/hive-metastore-client/releases/tag/1.0.8)
 ### Changed
-* Added if clause to check the default values for `TableBuilder` and `SerdeInfoBuilder` constructor
+* Replaced default values for `TableBuilder` and `SerdeInfoBuilder` constructors when no value is provided for specific lists and dicts
   ([#62](https://github.com/quintoandar/hive-metastore-client/pull/62))
 
 ## [1.0.7](https://github.com/quintoandar/hive-metastore-client/releases/tag/1.0.7)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 __package_name__ = "hive_metastore_client"
-__version__ = "1.0.7"
+__version__ = "1.0.8"
 __repository_url__ = "https://github.com/quintoandar/hive-metastore-client"
 
 with open("requirements.txt") as f:


### PR DESCRIPTION
## Why? :open_book:
Release version 1.0.8

## What? :wrench:
### Added
* Added if clause to check the default values for TableBuilder and SerdeInfoBuilder constructor
  ([#62](https://github.com/quintoandar/hive-metastore-client/pull/62))

## Type of change :file_cabinet:
- [x] Release

## Checklist :memo:
- [x] I have added labels to distinguish the type of pull request.
- [x] My code follows the style guidelines of this project (docstrings, type hinting, and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] I have made sure that new and existing unit tests pass locally with my changes;