### PR TITLE
Remove exception when getting partition values

### DIFF
--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -368,19 +368,22 @@ class HiveMetastoreClient(ThriftClient):
         :param db_name: database name where the table is at
         :param table_name: table name which the partitions belong to
         """
-        try:
+
+        partition_keys = self.get_partition_keys_objects(
+            db_name=db_name, table_name=table_name
+        )
+
+        partitions = []
+        if partition_keys:
             partition_values_response = self.get_partition_values(
                 PartitionValuesRequest(
                     dbName=db_name,
                     tblName=table_name,
-                    partitionKeys=self.get_partition_keys_objects(
-                        db_name=db_name, table_name=table_name
-                    ),
+                    partitionKeys=partition_keys,
                 )
             )
             partitions = [
                 partition.row for partition in partition_values_response.partitionValues
             ]
-        except Exception:
-            partitions = []
+
         return partitions

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -368,7 +368,6 @@ class HiveMetastoreClient(ThriftClient):
         :param db_name: database name where the table is at
         :param table_name: table name which the partitions belong to
         """
-
         partition_keys = self.get_partition_keys_objects(
             db_name=db_name, table_name=table_name
         )

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -377,9 +377,7 @@ class HiveMetastoreClient(ThriftClient):
         if partition_keys:
             partition_values_response = self.get_partition_values(
                 PartitionValuesRequest(
-                    dbName=db_name,
-                    tblName=table_name,
-                    partitionKeys=partition_keys,
+                    dbName=db_name, tblName=table_name, partitionKeys=partition_keys,
                 )
             )
             partitions = [

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -598,11 +598,9 @@ class TestHiveMetastoreClient:
         database_name = "database_name"
 
         mocked_partition_a = Mock()
-        mocked_partition_a.name = "mocked_partition_a"
-        mocked_partition_a.type = "string"
+        mocked_partition_a.name = "partition_key_1"
         mocked_partition_b = Mock()
-        mocked_partition_b.name = "mocked_partition_b"
-        mocked_partition_b.type = "string"
+        mocked_partition_b.name = "partition_key_2"
         mocked_get_partition_keys_objects.return_value = [
             mocked_partition_a,
             mocked_partition_b,

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -596,6 +596,18 @@ class TestHiveMetastoreClient:
         # arrange
         table_name = "table_name"
         database_name = "database_name"
+
+        mocked_partition_a = Mock()
+        mocked_partition_a.name = "mocked_partition_a"
+        mocked_partition_a.type = "string"
+        mocked_partition_b = Mock()
+        mocked_partition_b.name = "mocked_partition_b"
+        mocked_partition_b.type = "string"
+        mocked_get_partition_keys_objects.return_value = [
+            mocked_partition_a,
+            mocked_partition_b,
+        ]
+
         mocked_partition_values_response = Mock()
         mocked_partition_values = []
 
@@ -610,7 +622,9 @@ class TestHiveMetastoreClient:
         mocked_partition_values_response.partitionValues = mocked_partition_values
         mocked_get_partition_values.return_value = mocked_partition_values_response
         expected_partition_values_request = PartitionValuesRequest(
-            dbName=database_name, tblName=table_name, partitionKeys=[],
+            dbName=database_name,
+            tblName=table_name,
+            partitionKeys=mocked_get_partition_keys_objects.return_value,
         )
         expected_return = [["partition_a"], ["partition_b"]]
 

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -658,9 +658,6 @@ class TestHiveMetastoreClient:
         mocked_get_partition_keys_objects.assert_called_once_with(
             db_name=database_name, table_name=table_name
         )
-        mocked_get_partition_values.assert_called_once_with(
-            expected_partition_values_request
-        )
 
     @mock.patch.object(
         HiveMetastoreClient, "get_partition_keys_objects", return_value=[]


### PR DESCRIPTION
## Why? :open_book:
Code on `get_partition_values_from_table` was catch a too general exception unnecessarily.
It also caused exceptions on the Hive Metastore.

## What? :wrench:
Replaces a try-catch statement to an if.

## Type of change :file_cabinet:
- [x] Bug fix (non-breaking change which fixes an issue)

## How everything was tested? :straight_ruler:
- Unit tests running
- Stage test environment:
  - Returning same correct partition values for parquet partitioned tables
  - Returning same correct partition values for json partitioned tables
  - Returning same results (empty list) for json unpartitioned tables
  - Not raising exceptions on HMS

## Checklist :memo:
- [ ] I have added labels to distinguish the type of pull request.
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] I have made sure that new and existing unit tests pass locally with my changes;
