### PR TITLE
Release 1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 Preferably use **Added**, **Changed**, **Removed** and **Fixed** topics in each release or unreleased log for a better organization.
 
+## [1.0.9](https://github.com/quintoandar/hive-metastore-client/releases/tag/1.0.9)
+### Fixed
+* Stop inducing exception on Hive Metastore server when trying to retrieve partition values with `get_partition_values_from_table` for partitionless tables.
+  ([#64](https://github.com/quintoandar/hive-metastore-client/pull/64))
+
 ## [1.0.8](https://github.com/quintoandar/hive-metastore-client/releases/tag/1.0.8)
 ### Changed
 * Replaced default values for `TableBuilder` and `SerdeInfoBuilder` constructors when no value is provided for specific lists and dicts

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 __package_name__ = "hive_metastore_client"
-__version__ = "1.0.8"
+__version__ = "1.0.9"
 __repository_url__ = "https://github.com/quintoandar/hive-metastore-client"
 
 with open("requirements.txt") as f:


### PR DESCRIPTION
## Why? :open_book:
Release 1.0.9

## What? :wrench:
* Stop inducing exception on Hive Metastore server when trying to retrieve partition values with `get_partition_values_from_table` for partitionless tables.
  ([#64](https://github.com/quintoandar/hive-metastore-client/pull/64))

## Type of change :file_cabinet:
- [x] Release

## Checklist :memo:
- [x] I have added labels to distinguish the type of pull request.
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] I have made sure that new and existing unit tests pass locally with my changes;