### PR TITLE
add method get_schema

### DIFF
--- a/docs/source/getstarted.md
+++ b/docs/source/getstarted.md
@@ -40,6 +40,8 @@ Click on the following links to open the [examples](https://github.com/quintoand
 
 **[#11 Get partition values from a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/get_partition_values_from_table.py)**
 
+**[#12 Get field schema from a table](https://github.com/quintoandar/hive-metastore-client/blob/main/examples/get_field_schema.py)**
+
 ## Available methods
 
 You can see all the Hive Metastore server available methods by looking at the 
@@ -60,3 +62,4 @@ the [`HiveMetastoreClient`](https://github.com/quintoandar/hive-metastore-client
 - [`get_partition_keys_names`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.get_partition_keys_names)
 - [`bulk_drop_partitions`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.bulk_drop_partitions)
 - [`get_partition_values_from_table`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.get_partition_values_from_table)
+- [`get_field_schema`](https://hive-metastore-client.readthedocs.io/en/latest/hive_metastore_client.html#hive_metastore_client.hive_metastore_client.HiveMetastoreClient.get_field_schema)

--- a/examples/get_field_schema.py
+++ b/examples/get_field_schema.py
@@ -1,0 +1,11 @@
+from hive_metastore_client import HiveMetastoreClient
+
+HIVE_HOST = "<ADD_HIVE_HOST_HERE>"
+HIVE_PORT = 9083
+
+DATABASE_NAME = "database_name"
+TABLE_NAME = "table_name"
+
+with HiveMetastoreClient(HIVE_HOST, HIVE_PORT) as hive_client:
+    # Retrieving the partition keys and types via table schema
+    returned_value = hive_client.get_field_schema(DATABASE_NAME, TABLE_NAME)

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -384,3 +384,15 @@ class HiveMetastoreClient(ThriftClient):
             ]
 
         return partitions
+
+    def get_field_schema(self, db_name: str, table_name: str) -> List[FieldSchema]:
+        """
+        Gets a list of field schema from a table.
+
+        An empty list will be returned when no table is found or
+        no database is found
+
+        :param db_name: database name where the table is at
+        :param table_name: table name which the partition keys belong to
+        """
+        return self.get_schema(db_name, table_name)

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -720,3 +720,26 @@ class TestHiveMetastoreClient:
         mocked_get_partition_keys_objects.assert_called_once_with(
             db_name=db_name, table_name=table_name
         )
+
+    @mock.patch.object(HiveMetastoreClient, "get_schema", return_value=None)
+    def test_get_schema_with_non_empty_schema(
+        self, mocked_get_schema, hive_metastore_client,
+    ):
+        # arrange
+        table_name = "table_name"
+        database_name = "database_name"
+
+        mocked_field_schema_a = FieldSchema(name="col1")
+        mocked_field_schema_b = FieldSchema(name="col12")
+        mocked_get_schema.return_value = [mocked_field_schema_a, mocked_field_schema_b]
+
+        # act
+        returned_value = hive_metastore_client.get_field_schema(
+            database_name, table_name
+        )
+
+        # assert
+        assert returned_value == [mocked_field_schema_a, mocked_field_schema_b]
+        mocked_get_schema.assert_called_once_with(
+            dbname=database_name, tbl_name=table_name
+        )


### PR DESCRIPTION
- get_schema is a native and supported hive metadata call defined in the thrift

## Why? :open_book:
`get_schema` can return the a List[FieldSchema] for a given database and table. This is useful for users to get each field (primarily name, type) of the table.

## What? :wrench:
hive_metastore_client/hive_metastore_client.py

## Type of change :file_cabinet:
- [ ] New feature (non-breaking change which adds functionality)

## Checklist :memo:
- [ ] I have added labels to distinguish the type of pull request.
- [ ] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [ ] I have performed a self-review of my own code;
- [ ] I have made corresponding changes to the documentation;
- [ ] I have added tests that prove my fix is effective or that my feature works;
- [ ] I have made sure that new and existing unit tests pass locally with my changes;

