### PR TITLE
Update Workflow runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
   Pipeline:
     if: github.ref == 'refs/heads/main' || contains(github.ref, 'hotfix/')
 
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-22.04
     container: quintoandar/python-3-7-java
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   Pipeline:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-22.04
     container: quintoandar/python-3-7-java
 
     steps:

--- a/examples/add_partitions_if_not_exists.py
+++ b/examples/add_partitions_if_not_exists.py
@@ -11,10 +11,14 @@ TABLE_NAME = "table_name"
 # values should be passed in the same hierarchical order of the partitions
 partition_list = [
     PartitionBuilder(
-        values=["2020", "12", "13"], db_name=DATABASE_NAME, table_name=TABLE_NAME,
+        values=["2020", "12", "13"],
+        db_name=DATABASE_NAME,
+        table_name=TABLE_NAME,
     ).build(),
     PartitionBuilder(
-        values=["2020", "12", "14"], db_name=DATABASE_NAME, table_name=TABLE_NAME,
+        values=["2020", "12", "14"],
+        db_name=DATABASE_NAME,
+        table_name=TABLE_NAME,
     ).build(),
 ]
 

--- a/examples/add_partitions_to_table.py
+++ b/examples/add_partitions_to_table.py
@@ -11,10 +11,14 @@ TABLE_NAME = "table_name"
 # values should be passed in the same hierarchical order of the partitions
 partition_list = [
     PartitionBuilder(
-        values=["2020", "12", "16"], db_name=DATABASE_NAME, table_name=TABLE_NAME,
+        values=["2020", "12", "16"],
+        db_name=DATABASE_NAME,
+        table_name=TABLE_NAME,
     ).build(),
     PartitionBuilder(
-        values=["2020", "12", "17"], db_name=DATABASE_NAME, table_name=TABLE_NAME,
+        values=["2020", "12", "17"],
+        db_name=DATABASE_NAME,
+        table_name=TABLE_NAME,
     ).build(),
 ]
 

--- a/hive_metastore_client/hive_metastore_client.py
+++ b/hive_metastore_client/hive_metastore_client.py
@@ -376,7 +376,9 @@ class HiveMetastoreClient(ThriftClient):
         if partition_keys:
             partition_values_response = self.get_partition_values(
                 PartitionValuesRequest(
-                    dbName=db_name, tblName=table_name, partitionKeys=partition_keys,
+                    dbName=db_name,
+                    tblName=table_name,
+                    partitionKeys=partition_keys,
                 )
             )
             partitions = [

--- a/requirements.lint.txt
+++ b/requirements.lint.txt
@@ -1,4 +1,4 @@
-black==19.10b0
+black==22.3.0
 flake8==3.7.9
 flake8-docstrings==1.5.0
 mypy==0.782

--- a/tests/unit/hive_metastore_client/test_hive_metastore_client.py
+++ b/tests/unit/hive_metastore_client/test_hive_metastore_client.py
@@ -380,7 +380,9 @@ class TestHiveMetastoreClient:
 
     @mock.patch.object(HiveMetastoreClient, "create_database")
     def test_create_database_if_not_exists_with_nonexistent_database(
-        self, mocked_create_database, hive_metastore_client,
+        self,
+        mocked_create_database,
+        hive_metastore_client,
     ):
         # arrange
         mocked_database_obj = Mock()
@@ -393,7 +395,9 @@ class TestHiveMetastoreClient:
 
     @mock.patch.object(HiveMetastoreClient, "create_database")
     def test_create_database_if_not_exists_with_existent_database(
-        self, mocked_create_database, hive_metastore_client,
+        self,
+        mocked_create_database,
+        hive_metastore_client,
     ):
         # arrange
         mocked_database_obj = Mock()
@@ -427,7 +431,9 @@ class TestHiveMetastoreClient:
 
     @mock.patch.object(HiveMetastoreClient, "get_table", return_value=None)
     def test_get_partition_keys_objects_with_invalid_table(
-        self, mocked_get_table, hive_metastore_client,
+        self,
+        mocked_get_table,
+        hive_metastore_client,
     ):
         # arrange
         table_name = "table_name"
@@ -446,7 +452,9 @@ class TestHiveMetastoreClient:
 
     @mock.patch.object(HiveMetastoreClient, "get_table")
     def test_get_partition_keys_objects_with_not_partitioned_table(
-        self, mocked_get_table, hive_metastore_client,
+        self,
+        mocked_get_table,
+        hive_metastore_client,
     ):
         # arrange
         table_name = "table_name"
@@ -469,7 +477,9 @@ class TestHiveMetastoreClient:
 
     @mock.patch.object(HiveMetastoreClient, "get_table")
     def test_get_partition_keys_objects_with_partitioned_table(
-        self, mocked_get_table, hive_metastore_client,
+        self,
+        mocked_get_table,
+        hive_metastore_client,
     ):
         # arrange
         table_name = "table_name"
@@ -495,7 +505,9 @@ class TestHiveMetastoreClient:
         HiveMetastoreClient, "get_partition_keys_objects", return_value=[]
     )
     def test_get_partition_keys_names_with_invalid_or_not_partitioned_table(
-        self, mocked_get_partition_keys_objects, hive_metastore_client,
+        self,
+        mocked_get_partition_keys_objects,
+        hive_metastore_client,
     ):
         # arrange
         table_name = "table_name"
@@ -516,7 +528,9 @@ class TestHiveMetastoreClient:
         HiveMetastoreClient, "get_partition_keys_objects", return_value=[]
     )
     def test_get_partition_keys_names_with_partitioned_table(
-        self, mocked_get_partition_keys_objects, hive_metastore_client,
+        self,
+        mocked_get_partition_keys_objects,
+        hive_metastore_client,
     ):
         # arrange
         table_name = "table_name"
@@ -654,7 +668,9 @@ class TestHiveMetastoreClient:
 
         mocked_get_partition_keys_objects.return_value = []
         expected_partition_values_request = PartitionValuesRequest(
-            dbName=database_name, tblName=table_name, partitionKeys=[],
+            dbName=database_name,
+            tblName=table_name,
+            partitionKeys=[],
         )
 
         mocked_get_partition_values.side_effect = [TTransportException()]


### PR DESCRIPTION
## Why? :open_book:
The runner used for executing the Github Actions appears to be outdated and not working.
The step will be stuck finding for a runner:
<img width="687" alt="image" src="https://user-images.githubusercontent.com/13151948/184149804-2c214f58-b2cd-4a96-a0aa-7fba5015ca32.png">


## What? :wrench:
- updating the runner to `ubuntu-22.04`
- updating black due to dependencies issue

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How everything was tested? :straight_ruler:
Running PR workflows
