### PR TITLE
Bump Sphinx version

### DIFF
--- a/docs/requirements.docs.txt
+++ b/docs/requirements.docs.txt
@@ -1,5 +1,5 @@
 recommonmark==0.6.0
-Sphinx==3.1.1
+Sphinx==5.1.1
 sphinx-rtd-theme==0.4.3
 sphinxemoji==0.1.6
 typing-extensions==3.7.4.2

--- a/docs/source/hive_metastore_client.builders.rst
+++ b/docs/source/hive_metastore_client.builders.rst
@@ -46,7 +46,6 @@ Submodules
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/docs/source/hive_metastore_client.rst
+++ b/docs/source/hive_metastore_client.rst
@@ -18,7 +18,6 @@ Submodules
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 


### PR DESCRIPTION
## Why? :open_book:
The docs on Read the Docs site are not being built.

## What? :wrench:
Bump local Sphinx to the version used in ReadTheDocs.
update some docs to test building

## Type of change :file_cabinet:
- [ ] Documentation

## How everything was tested? :straight_ruler:
Locally

## Checklist :memo:
- [ ] I have added labels to distinguish the type of pull request.
- [ ] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [ ] I have performed a self-review of my own code;
- [ ] I have made corresponding changes to the documentation;
- [ ] I have added tests that prove my fix is effective or that my feature works;
- [ ] I have made sure that new and existing unit tests pass locally with my changes;

## Attention Points :warning:
_Replace me for what the reviewer will need to pay attention to in the PR or just to cover any concerns after the merge._
